### PR TITLE
Atlas opendata bumpnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Thumbs.db
 
 # Misc
 *.log
+atlasenv/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,225 @@
+# ATLAS Open Data → BumpNet Pipeline
+
+This branch contains fixes and extensions to the ATLAS utilization pipeline
+for processing ATLAS Open Data PHYSLITE files and producing invariant mass
+histograms for the BumpNet anomaly detection algorithm.
+
+## Branch: `atlas-opendata-bumpnet`
+
+Based on: `master` of [atlas-utilization](https://github.com/Zhavi221/atlas-utilization)
+
+---
+
+## Summary of Changes
+
+### Fix 1 — Index-based IM naming (`im_pipeline.py`, `histograms_pipeline.py`)
+
+**Problem:** The pipeline used count-based naming for invariant mass combinations,
+e.g. `IM_2e_0m_1j_0g`, which is ambiguous — it does not specify *which* particles
+were used (leading vs sub-leading). BumpNet expects index-based naming starting
+from 0 (e.g. `e0`, `e1`, `j0`).
+
+**Fix:** Two functions were updated:
+- `prepare_im_combination_name` in `services/pipelines/im_pipeline.py`
+- `_convert_to_bumpnet_name` in `services/pipelines/histograms_pipeline.py`
+
+**Result:**
+
+| Old signature | New signature | Meaning |
+|---|---|---|
+| `IM_1e_0m_1j_0g` | `IM_e0j0` | leading e + leading j (2-body) |
+| `IM_2e_0m_1j_0g` | `IM_e0e1j0` | both e + leading j (3-body) |
+| `IM_1e_0m_2j_0g` | `IM_e0j0j1` | leading e + both j (3-body) |
+
+Histogram names follow the same convention:
+`ROI_mass_e0j0_cat_1ex_0mx_1jx_0gx_width_10.0`
+
+---
+
+### Fix 2 — Kinematic cuts in MeV (`config10GeVbin.yaml`)
+
+**Problem:** ATLAS PHYSLITE stores all 4-vector quantities (pt, mass, energy) in
+MeV. The original config used `pt_min: 25.0`, which meant 25 MeV — effectively
+no cut, passing all soft particles and producing unphysical invariant masses.
+
+**Fix:** Config updated to use MeV values:
+
+```yaml
+kinematic_cuts:
+  electrons: { pt_min: 25000.0, eta_max: 2.47 }  # 25 GeV in MeV
+  muons:     { pt_min: 25000.0, eta_max: 2.5  }
+  jets:      { pt_min: 30000.0, eta_max: 4.5  }
+  photons:   { pt_min: 25000.0, eta_max: 2.37 }
+```
+
+The `_convert_array_to_gev()` function (`* 1e-3`) in `im_pipeline.py` correctly
+converts MeV → GeV for the final invariant mass values stored in SQLite.
+
+---
+
+### Fix 3 — Memory leak in `parsing_handler.py`
+
+**Problem:** After writing each parsed ROOT chunk to disk, the Python `EventChunk`
+object (holding large awkward arrays) was not explicitly freed. Python's garbage
+collector does not release memory promptly, causing memory to grow continuously
+throughout a long parsing job — reaching 150+ GB for a 72-hour run over 70,201
+files.
+
+**Fix:** Added explicit memory release after each chunk write:
+
+```python
+import gc
+
+# After _save_chunk_to_root(chunk, ...):
+del chunk
+gc.collect()
+
+# After _save_chunk_to_root(final_chunk, ...):
+del final_chunk
+gc.collect()
+```
+
+The ROOT files on disk are unaffected — only the in-memory Python object is freed.
+
+---
+
+### Fix 4 — Parsing config: reduced memory thresholds
+
+**Problem:** `chunk_yield_threshold_bytes: 2147483648` (2 GB) combined with
+`threads: 8` allowed up to 16 GB of awkward arrays to accumulate before any
+flush, leading to memory explosions when running all pipeline stages in one job.
+
+**Fix** in `config10GeVbin.yaml`:
+
+```yaml
+parsing_task_config:
+  chunk_yield_threshold_bytes: 268435456  # 256 MB — flush frequently
+  threads: 2                              # reduce from 8
+```
+
+---
+
+## New Files
+
+### `config10GeVbin.yaml`
+Main config for the ATLAS Open Data BumpNet run. Key settings:
+- 10 GeV bin width for histograms
+- Correct MeV kinematic cuts
+- Reduced memory thresholds
+- `max_particles_in_combination: 2` for initial validation run
+  (increase to 4 for full combination set)
+
+### `submit_parsing_only.sh`
+Submits a single PBS job that runs **only the parsing stage**.
+Mass calculation is intentionally excluded to prevent memory explosion.
+
+Usage:
+```bash
+bash submit_parsing_only.sh
+# prints RUN_DIR when submitted — use it for mass calculation step
+```
+
+After parsing completes:
+```bash
+RUN_DIR=/path/to/run_dir bash submit_mass_calc.sh
+```
+
+### `submit_mass_calc.sh`
+Submits one PBS job **per parsed ROOT chunk** for mass calculation.
+Each job processes exactly one ~2 GB chunk, keeping memory under 16 GB.
+A dependent post-processing + histogram job is submitted automatically
+after all chunk jobs complete.
+
+Usage:
+```bash
+# Use default RUN_DIR (hardcoded in script):
+bash submit_mass_calc.sh
+
+# Or override RUN_DIR:
+RUN_DIR=/path/to/run_dir bash submit_mass_calc.sh
+```
+
+Key settings per job:
+- `io=31` (measured with `iothrottle -v -l 0`)
+- `walltime=00:15:00` (one chunk takes ~52 seconds)
+- `mem=16gb`
+- `use_multiprocessing: false`, `parallel_processes: 1`
+
+---
+
+## Pipeline Architecture
+
+```
+Raw PHYSLITE files (CERN EOS, streamed via XRootD)
+         ↓
+  ParsingHandler
+  - Reads AnalysisElectronsAuxDyn.pt etc. (values in MeV)
+  - Applies kinematic cuts (pt_min in MeV)
+  - Writes parsed_data/parsed_2024r-pp_chunk{N}.root
+         ↓
+  MassCalculationHandler  (one PBS job per chunk)
+  - Computes invariant masses for all particle combinations
+  - Converts MeV → GeV via _convert_array_to_gev() × 1e-3
+  - Writes im_arrays/im_batch_{N}.sqlite
+         ↓
+  PostProcessingHandler
+  - Removes known SM resonance peaks (Z, W)
+  - Splits into main / outlier arrays
+         ↓
+  HistogramCreationHandler
+  - Builds ROOT histograms with BumpNet index-based naming
+  - Output: histograms/atlas_opendata_full_bumpnet.root
+```
+
+---
+
+## Known Issues / Pending Work
+
+### Sub-leading particle combinations (Fix 2 — not yet implemented)
+The current code always selects leading particles (highest pT) for each
+combination. `{"Electrons": 1}` always means e₀ (leading electron).
+There is no mechanism to compute e₁+j₀ (sub-leading electron + leading jet)
+as a separate 2-body invariant mass.
+
+Files to modify: `services/calculations/combinatorics.py`,
+`services/calculations/physics_calcs.py`,
+`services/pipelines/mass_calculation_handler.py`
+
+### Electron isolation cuts (not yet implemented)
+The electron validation plot shows a flat tail from 1000–5000 GeV due to
+the absence of isolation cuts. Standard ATLAS isolation requirements:
+- `ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000 / pt < 0.06`
+- `topoetcone20 / pt < 0.06`
+
+These branches are available in PHYSLITE and need to be added to the
+parsing stage `filter_events_by_kinematics`.
+
+### Z peak removal for multi-body final states
+`_find_rightmost_highest_peak` fails for 3-body distributions (e.g. μ₀+μ₁+j₀)
+where the highest bin is the low-mass turn-on, not the Z+jet peak at ~117 GeV.
+BumpNet flags this as a 5σ excess. The peak removal algorithm needs to be
+updated for multi-body final states.
+
+---
+
+## Data Notes
+
+- ATLAS Open Data 2024r-pp release: 70,201 files, ~65 TB
+- pT stored in MeV in all PHYSLITE branches
+- Parsed data: ~107 chunks × ~2 GB = ~183 GB (15% of full dataset)
+- Full dataset parsing: ~22–30 hours on a single PBS node
+- Mass calculation: ~52 seconds per chunk with `max_particles_in_combination: 2`
+
+---
+
+## How to Add This README to the Branch
+
+```bash
+# Save this file as CHANGES.md in the repository root
+cp CHANGES.md /path/to/atlas-utilization/CHANGES.md
+
+cd /path/to/atlas-utilization
+git add CHANGES.md
+git commit -m "Add CHANGES.md documenting Open Data BumpNet fixes"
+git push origin atlas-opendata-bumpnet
+```

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,7 @@ Histogram names follow the same convention:
 
 ---
 
-### Fix 2 — Kinematic cuts in MeV (`config10GeVbin.yaml`)
+### Fix 2 — Kinematic cuts in MeV (`config.yaml`)
 
 **Problem:** ATLAS PHYSLITE stores all 4-vector quantities (pt, mass, energy) in
 MeV. The original config used `pt_min: 25.0`, which meant 25 MeV — effectively
@@ -89,7 +89,7 @@ The ROOT files on disk are unaffected — only the in-memory Python object is fr
 `threads: 8` allowed up to 16 GB of awkward arrays to accumulate before any
 flush, leading to memory explosions when running all pipeline stages in one job.
 
-**Fix** in `config10GeVbin.yaml`:
+**Fix** in `config.yaml`:
 
 ```yaml
 parsing_task_config:
@@ -101,7 +101,7 @@ parsing_task_config:
 
 ## New Files
 
-### `config10GeVbin.yaml`
+### `config.yaml`
 Main config for the ATLAS Open Data BumpNet run. Key settings:
 - 10 GeV bin width for histograms
 - Correct MeV kinematic cuts
@@ -206,20 +206,5 @@ updated for multi-body final states.
 
 - ATLAS Open Data 2024r-pp release: 70,201 files, ~65 TB
 - pT stored in MeV in all PHYSLITE branches
-- Parsed data: ~107 chunks × ~2 GB = ~183 GB (15% of full dataset)
-- Full dataset parsing: ~22–30 hours on a single PBS node
-- Mass calculation: ~52 seconds per chunk with `max_particles_in_combination: 2`
 
 ---
-
-## How to Add This README to the Branch
-
-```bash
-# Save this file as CHANGES.md in the repository root
-cp CHANGES.md /path/to/atlas-utilization/CHANGES.md
-
-cd /path/to/atlas-utilization
-git add CHANGES.md
-git commit -m "Add CHANGES.md documenting Open Data BumpNet fixes"
-git push origin atlas-opendata-bumpnet
-```

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,129 @@ Based on: `master` of [atlas-utilization](https://github.com/Zhavi221/atlas-util
 
 ## Summary of Changes
 
+### Fix 12 — Histogram bin-edge mismatch across batches (`histograms_pipeline.py`, `executor.py`, `utils/paths.py`)
+
+**Problem:** Each histogram batch job computed `global_min`/`global_max` from its
+own data slice, producing histograms with different bin edges per batch. `hadd`
+silently kept only the first batch's histogram and discarded the rest — e.g. for
+`mass_m0m1j0_cat_2mx_1jx`, batch_1 had `nbins=33 min=59.8 max=397.5` while
+batch_3 had `nbins=254 min=62.3 max=2598.7`. The merged file contained only
+batch_1's 33 events instead of the true ~52,000.
+
+**Fix:** Introduced a mandatory scan step between post-processing and histogram
+creation. The scan reads all processed SQLite files, computes the true global
+min/max per bumpnet signature across all batches and chunks, and writes
+`logs/global_ranges.json`. All histogram batch jobs load this file and use
+identical bin edges. `hadd` now merges correctly.
+
+**New `--scan-only` mode** in `main.py` + `scan_global_ranges()` in `executor.py`:
+```bash
+python main.py --scan-only --run-dir /path/to/run_dir
+```
+
+**New helper functions** in `histograms_pipeline.py`:
+```python
+compute_global_ranges(sqlite_files, input_dir, exclude_outliers)
+save_global_ranges(ranges, output_path)
+load_global_ranges(path)
+```
+
+**`utils/paths.py`:** `update_config_paths_with_run_dir` now always sets
+`global_ranges_path = {run_dir}/logs/global_ranges.json` automatically — no
+manual config change needed.
+
+**PBS job chain updated** (`submit_data.sh`, `submit_mc.sh`):
+
+---
+
+### Fix 13 — MC/data contamination in pipeline runs (`submit_data.sh`, `submit_mc.sh`, `main.py`)
+
+**Problem:** Data and MC files were parsed into the same run directory. With
+`parse_mc=False` the metadata cache still contained MC URLs (see Fix 11), and
+the pipeline had no clean mechanism to enforce full separation at the run level.
+
+**Fix:** Separated into two independent submission scripts:
+- `submit_data.sh` — creates `{run_name}_data_{TIMESTAMP}/`, passes `--parse-mc false`
+- `submit_mc.sh` — creates `{run_name}_mc_{TIMESTAMP}/`, passes `--parse-mc true`
+
+Both scripts use the same config file. A new `--parse-mc true/false` CLI flag
+overrides `parse_mc` in `parsing_task_config` at runtime without editing YAML:
+
+```bash
+# in submit_data.sh:
+python -u main.py --config "${CONFIG}" --parse-mc false ...
+
+# in submit_mc.sh:
+python -u main.py --config "${CONFIG}" --parse-mc true ...
+```
+
+Both scripts implement the full 4-stage PBS chain from Fix 12.
+
+---
+
+### Fix 14 — Batch file deletion after hadd destroyed retry runs (`executor.py`)
+
+**Problem:** `merge_outputs` called `bf.unlink()` on each `batch_N.root` file
+after a successful `hadd`. On retry runs (e.g. after a failed batch job was
+resubmitted), only the new batch file existed — `hadd` merged just 1 file instead
+of all N, silently overwriting the previously correct merged file.
+
+**Fix:** Batch files are now moved to `histograms/batch_files_archive/` instead
+of deleted:
+```python
+archive_dir = Path(hist_dir) / "batch_files_archive"
+archive_dir.mkdir(exist_ok=True)
+for bf in batch_roots:
+    bf.rename(archive_dir / bf.name)
+```
+
+---
+
+### Fix 15 — Stats aggregation crash on float-valued fields (`executor.py`)
+
+**Problem:** `_aggregate_batch_stats` called `int(p[key])` on fields like
+`total_size_mb` which are stored as floats (e.g. `'0.00'`), raising
+`ValueError: invalid literal for int() with base 10: '0.00'`.
+
+**Fix:** `int(float(p[key]))` — converts to float first, then truncates to int.
+
+---
+
+### Fix 16 — Memory crash in plot generation (`executor.py`)
+
+**Problem:** `_read_parsed_data_stats` accumulated full per-event particle count
+arrays (`particle_dists[ptype].extend(counts.tolist())`) across all 671 parsed
+ROOT files. With millions of events per file this exhausted memory on the login
+node, killing the process silently with no traceback.
+
+**Fix:** Replaced array accumulation with immediate summation:
+```python
+counts = tree[branch_name].array(library="np")
+particle_counts[ptype] = particle_counts.get(ptype, 0) + int(np.sum(counts))
+del counts  # free immediately
+```
+`distributions` dict is now always empty — too large to store for runs of this size.
+
+---
+
+### Feature — Pre-post-processing histograms (`executor.py`, `histogram_creation_task_config`)
+
+**Motivation:** Comparing histograms before and after post-processing is essential
+for validating peak removal. Previously this required a separate manual submission
+script (`submit_hist_up4j_v2.sh`).
+
+**New config options:**
+```yaml
+histogram_creation_task_config:
+  also_save_pre_postproc: true
+  pre_postproc_filename: "atlas_opendata_nopostproc.root"
+```
+
+When enabled, the merge job reads all `im_arrays/*.sqlite` files (raw invariant
+mass arrays, before peak removal) and writes a second ROOT file alongside the
+main post-processed one. Produced in the merge step to avoid the bin-edge problem
+— all data is visible at once, no batching required.
+
 ## Fix 11 — prevent MC/data contamination in metadata cache
 
 **Problem:**The previous `_separate_mc_files` used `"mc" in url.lower()` which is

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -245,13 +245,6 @@ mass_calculation_task_config:
   max_total_particles_in_combination: 4  # default; reduces 624 → 69 combinations
 ```
 
-| Config | Combinations |
-|--------|-------------|
-| No cap | 624 |
-| cap=2  | 14  |
-| cap=3  | 34  |
-| cap=4  | 69  |
-
 ---
 
 ### Fix 6 — Post-processing: merge all chunks by FS_IM key before peak detection (`post_processing_pipeline.py`)
@@ -406,76 +399,6 @@ gc.collect()
 
 The ROOT files on disk are unaffected — only the in-memory Python object is freed.
 
----
-
-### Fix 4 — Parsing config: reduced memory thresholds
-
-**Problem:** `chunk_yield_threshold_bytes: 2147483648` (2 GB) combined with
-`threads: 8` allowed up to 16 GB of awkward arrays to accumulate before any
-flush, leading to memory explosions when running all pipeline stages in one job.
-
-**Fix** in `config.yaml`:
-
-```yaml
-parsing_task_config:
-  chunk_yield_threshold_bytes: 268435456  # 256 MB — flush frequently
-  threads: 2                              # reduce from 8
-```
-
----
-
-## New Files
-
-### `config.yaml`
-Main config for the ATLAS Open Data BumpNet run. Key settings:
-- 10 GeV bin width for histograms
-- Correct MeV kinematic cuts
-- Reduced memory thresholds
-- `max_particles_in_combination: 2` for initial validation run
-  (increase to 4 for full combination set)
-
-### `submit_parsing_only.sh`
-Submits a single PBS job that runs **only the parsing stage**.
-Mass calculation is intentionally excluded to prevent memory explosion.
-
-### `submit_mass_calc.sh`
-Submits one PBS job **per parsed ROOT chunk** for mass calculation.
-Each job processes exactly one ~2 GB chunk, keeping memory under 16 GB.
-A dependent post-processing + histogram job is submitted automatically
-after all chunk jobs complete.
-
-### `submit_mass_postproc.sh`
-Submits mass calculation array job + dependent post-processing + histogram
-creation job for an **existing** parsed data directory (no re-parsing).
-
-Usage:
-```bash
-RUN_DIR=/path/to/existing/run bash submit_mass_postproc.sh
-```
-
-### `submit_hist_asNeta.sh`
-Submits histogram creation only from existing processed SQLite files.
-Bypasses mass calculation and post-processing.
-
-### `submit_minEvt10.sh`
-Full pipeline submission for `min_events_per_fs=10` run, reusing existing
-parsed data. Handles data and MC separately to avoid SQLite locking conflicts.
-No `hadd` — histogram creation reads all SQLite files in one job.
-
-### `configAsNeta.yaml`
-Config matching Neta's parsing settings (25 MeV cuts, min_events=100).
-
-### `configWmaxTotal.yaml`
-Config with `max_total_particles_in_combination: 4`, `min_particles: 1`.
-
-### `configWmaxTotal_up4j.yaml`
-Config with `jets: max: 4`, `parse_mc: true` for data+MC runs.
-
-### `configWmaxTotal_up4j_minEvt10.yaml`
-Config with `min_events_per_fs: 10` to recover rare electron final states.
-
-### `env.sh`
-Environment setup script for the pipeline (LCG view + atlasenv activation).
 
 ---
 
@@ -509,16 +432,6 @@ Raw PHYSLITE files (CERN EOS, streamed via XRootD)
 
 ## Known Issues / Pending Work
 
-### Sub-leading particle combinations (not yet implemented)
-The current code always selects leading particles (highest pT) for each
-combination. `{"Electrons": 1}` always means e₀ (leading electron).
-There is no mechanism to compute e₁+j₀ (sub-leading electron + leading jet)
-as a separate 2-body invariant mass.
-
-Files to modify: `services/calculations/combinatorics.py`,
-`services/calculations/physics_calcs.py`,
-`services/pipelines/mass_calculation_handler.py`
-
 ### Electron isolation cuts (not yet implemented)
 Without isolation cuts, fake electrons from jets dominate the electron
 channel. The `2ex_0mx_1jx_0gx` final state has only ~1 event across
@@ -527,23 +440,8 @@ high-multiplicity fake-electron final states. Standard ATLAS isolation:
 - `ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000 / pt < 0.06`
 - `topoetcone20 / pt < 0.06`
 
-### SM background MC not available for 2024r-pp
-The `2024r-pp_mc` release via atlasopenmagic contains only BSM signal
-samples (Z', W', graviton — DSIDs 301xxx). No SM background MC (Z+jets,
-tt̄, W+jets, QCD) is available for the Run 3 open data release.
-Confirmed with ATLAS Open Data support.
-
 ### _split_by_first_empty_bin truncates sparse distributions
 For final states with low statistics (e.g. 2μ+1j), the first empty bin
 occurs early in the high-mass tail, causing the postproc histogram to
 be truncated. Use `exclude_outliers: false` in histogram creation to
 include the full distribution above the Z peak cut.
-
----
-
-## Data Notes
-
-- ATLAS Open Data 2024r-pp release: 70,201 files, ~65 TB
-- pT stored in MeV in all PHYSLITE branches
-- `2024r-pp_mc`: 14,581 files — BSM signal samples only (not SM background)
-- Luminosity: data ~140 fb⁻¹ (Run 3), MC weighted to match

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,27 @@ Based on: `master` of [atlas-utilization](https://github.com/Zhavi221/atlas-util
 
 ## Summary of Changes
 
+## Fix 11 — prevent MC/data contamination in metadata cache
+
+**Problem:**The previous `_separate_mc_files` used `"mc" in url.lower()` which is
+ambiguous — ATLAS Open Data URLs all contain "opendata", causing MC URLs
+to be misclassified. With `parse_mc=False`, no separation happened at
+all, so MC events were silently parsed as collision data.
+
+**Modified files:**:
+- fetcher.py: replace loose substring match with regex-based classifier
+  (_classify_url) anchored to the dataset namespace component (mc<N>_,
+  data<N>_). Separation now always happens unconditionally. Unclassifiable
+  URLs raise ValueError immediately — no silent misrouting.
+- fetcher.py: add _assert_no_cross_contamination() post-separation check
+  as a safety net.
+- fetch_metadata_handler.py: validate cache integrity on load; raise
+  RuntimeError with first 5 violations if contaminated, forcing cache
+  rebuild. Remove separate_mc argument from fetcher.fetch() call.
+- parsing_handler.py: skip keys ending in _mc when parse_mc=False.
+  parse_mc now means "include MC in the parsing run", not "separate in
+  cache" (separation is always performed).
+  
 ## Fix 10 — Sub-leading particle support
 
 **Problem:** All combinations used only leading particles (highest pT).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,18 @@ writer.commit()  # final commit for remainder
 **Result:** WAL stays small (~few MB), and at most 1000 signatures worth of work
 is lost on job kill.
 
+### Fix 9 — Skip single-particle combinations in combinatorics (`combinatorics.py`)
+
+Added a guard in `get_all_combinations` to reject combinations where the total
+particle count is less than 2. A single-particle "combination" produces a trivial
+invariant mass equal to the particle's own mass, which is physically meaningless
+for bump hunting. Previously, such combinations could pass the `max_total_particles`
+filter and propagate through the mass calculation, generating spurious signatures
+(e.g. `1e_0m_0j_0g`) that inflate the histogram count without any signal sensitivity.
+
+**Change:** `if sum(counts) < 2: continue`
+**Result:** Combinatorics now only generates signatures with ≥ 2 particles
+
 ---
 
 ### Fix 1 — Index-based IM naming (`im_pipeline.py`, `histograms_pipeline.py`)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,31 @@ Based on: `master` of [atlas-utilization](https://github.com/Zhavi221/atlas-util
 
 ## Summary of Changes
 
+## Fix 10 — Sub-leading particle support
+
+**Problem:** All combinations used only leading particles (highest pT).
+`{"Electrons": 1}` always meant e₀. There was no way to compute e₁+j₀
+(sub-leading electron + leading jet) as a separate invariant mass signature.
+
+**Solution:** Combination values are now `(count, start_index)` tuples.
+`start_index=0` = leading (unchanged behaviour); `start_index=1` = sub-leading.
+Plain `int` values are still accepted via `get_count()` / `get_start()` helpers
+for full backward compatibility.
+
+**New config flags** (in `mass_calculation_task_config`):
+```yaml
+include_subleading: false   # set true to activate
+max_subleading_index: 1     # highest rank index (1 = up to sub-leading)
+```
+
+**Impact:** With `max_subleading_index: 1`, enabling sub-leading expands
+combinations from 65 → 308 (~4.7×). Walltime should be scaled accordingly.
+
+**Modified files:** `combinatorics.py`, `physics_calcs.py`,
+`im_calculator.py`, `im_pipeline.py`, `domain/config.py`, `config.yaml`
+
+############################
+
 ### Fix 5 — max_total_particles_in_combination cap (`combinatorics.py`, `domain/config.py`, `mass_calculation_handler.py`)
 
 **Problem:** With `min_particles_in_combination: 1`, the number of IM combinations

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,49 @@ Based on: `master` of [atlas-utilization](https://github.com/Zhavi221/atlas-util
 
 ## Summary of Changes
 
+### Fix 17 — Histogram batch jobs not splitting SQLite files correctly (`histograms_pipeline.py`, `orchestration/handlers/histogram_creation_handler.py`, `main.py`, `domain/config.py`)
+
+**Problem:** Multiple issues caused all histogram batch jobs to process all
+processed SQLite files instead of their assigned slice, producing identical
+histograms in each batch that hadd summed incorrectly:
+
+1. `total_batch_jobs` was missing from the `config_dict` passed to
+   `create_histograms` — without it, `_create_histograms_from_sqlite` could
+   not split SQLite files by batch index.
+
+2. `global_ranges_path` was not passed through `HistogramCreationHandler` to
+   `create_histograms`, so `global_ranges` was always `None` and histograms
+   used batch-local bin edges instead of the global ones from `global_ranges.json`.
+
+3. `_create_histograms_from_sqlite` had no SQLite file splitting logic at all —
+   it always read all SQLite files regardless of `batch_job_index`.
+
+4. `batch_job_index` and `total_batch_jobs` were injected into
+   `histogram_creation_task_config` in `main.py` but only after
+   `update_config_paths_with_run_dir` was called, so the split never reached
+   `PipelineConfig`.
+
+5. `also_save_pre_postproc`, `pre_postproc_filename`, and `global_ranges_path`
+   were not defined as fields in `HistogramCreationConfig` or read in
+   `from_dict`, so YAML values were silently ignored.
+
+**Fixes:**
+
+- `histograms_pipeline.py`: added SQLite file splitting in
+  `_create_histograms_from_sqlite` using `_get_batch_files` when
+  `batch_job_index` and `total_batch_jobs` are present in config.
+
+- `histogram_creation_handler.py`: added `total_batch_jobs` and
+  `global_ranges_path` to the `config_dict` passed to `create_histograms`.
+
+- `main.py`: inject `batch_job_index` and `total_batch_jobs` into
+  `histogram_creation_task_config` alongside `output_filename`.
+
+- `domain/config.py`: added `global_ranges_path`, `also_save_pre_postproc`,
+  and `pre_postproc_filename` fields to `HistogramCreationConfig` dataclass
+  and wired them through `from_dict`.
+
+
 ### Fix 12 — Histogram bin-edge mismatch across batches (`histograms_pipeline.py`, `executor.py`, `utils/paths.py`)
 
 **Problem:** Each histogram batch job computed `global_min`/`global_max` from its
@@ -120,9 +163,7 @@ del counts  # free immediately
 ### Feature — Pre-post-processing histograms (`executor.py`, `histogram_creation_task_config`)
 
 **Motivation:** Comparing histograms before and after post-processing is essential
-for validating peak removal. Previously this required a separate manual submission
-script (`submit_hist_up4j_v2.sh`).
-
+for validating peak removal. 
 **New config options:**
 ```yaml
 histogram_creation_task_config:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -128,21 +128,11 @@ correctly identifying the Z peak at ~91 GeV even for sparse final states.
 
 ### Fix 7 — Post-processing: use right edge of peak bin (`post_processing_pipeline.py`)
 
-**Problem:** `_find_rightmost_highest_peak` returned `bin_edges[peak_bin_idx]`
-(the **left** edge of the peak bin). With 10 GeV bins, the Z peak bin spans
-81–91 GeV, so the cut kept events from 81 GeV onward — including the full Z peak.
+remove Fix 7 — peak bin right-edge shift had no effect
 
-**Fix:** Return `bin_edges[peak_bin_idx + 1]` (the **right** edge):
-
-```python
-# OLD:
-peak_mass = bin_edges[peak_bin_idx]
-# NEW:
-peak_mass = bin_edges[peak_bin_idx + 1]
-```
-
-**Result:** The full Z peak bin (e.g. 81–91 GeV) is now removed, producing
-a smooth falling distribution starting at ~91 GeV suitable for BumpNet.
+The peak_bin_idx + 1 change (right edge instead of left edge of peak bin)
+did not solve the post-processing problem. Root cause is elsewhere.
+Reverting to original behavior pending proper fix.
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,119 @@ Based on: `master` of [atlas-utilization](https://github.com/Zhavi221/atlas-util
 
 ## Summary of Changes
 
+### Fix 5 — max_total_particles_in_combination cap (`combinatorics.py`, `domain/config.py`, `mass_calculation_handler.py`)
+
+**Problem:** With `min_particles_in_combination: 1`, the number of IM combinations
+explodes to 624 (4 particle types, counts 1–4 each, no cap). Most high-multiplicity
+combinations (e.g. 4e+4μ+4j+4γ = 16 particles) are unphysical and produce
+negligible statistics, wasting mass calculation time.
+
+**Fix:** Added `max_total_particles_in_combination` parameter that skips any
+combination where the sum of particle counts exceeds the cap:
+
+```python
+# services/calculations/combinatorics.py
+for counts in itertools.product(*count_ranges):
+    if sum(counts) > max_total_particles:   # skip combinations exceeding particle cap
+        continue
+```
+
+Configurable via yaml:
+```yaml
+mass_calculation_task_config:
+  max_total_particles_in_combination: 4  # default; reduces 624 → 69 combinations
+```
+
+| Config | Combinations |
+|--------|-------------|
+| No cap | 624 |
+| cap=2  | 14  |
+| cap=3  | 34  |
+| cap=4  | 69  |
+
+---
+
+### Fix 6 — Post-processing: merge all chunks by FS_IM key before peak detection (`post_processing_pipeline.py`)
+
+**Problem:** The post-processing pipeline iterated over individual signatures like
+`parsed_2024r-pp_batch1_chunk0_FS_0e_0m_3j_0g_IM_j0j1j2`, processing each chunk
+independently. This caused the peak finder to see partial distributions (e.g.
+250k events from one chunk) rather than the full merged distribution (~2.5M
+events across all chunks and batches). On sparse per-chunk distributions the
+highest bin was often the low-mass turn-on, not the Z peak — leading to incorrect
+peak removal.
+
+**Fix:** Group all signatures by their `FS_IM` key (stripping the
+`parsed_..._batch{N}_chunk{M}` prefix) before peak detection, then load and
+concatenate all chunk arrays for that key:
+
+```python
+from collections import defaultdict
+fs_im_groups = defaultdict(list)
+for sig in signatures:
+    m = re.search(r'(_FS_.+)', sig)
+    fs_im_key = m.group(1) if m else sig
+    fs_im_groups[fs_im_key].append(sig)
+
+for fs_im_key in sorted(fs_im_groups.keys()):
+    chunks = []
+    for sig in fs_im_groups[fs_im_key]:
+        for filename in sqlite_files:
+            chunks.extend(iter_arrays_for_signature(..., sig))
+    arr = np.concatenate(chunks)
+    # peak detection on full merged array
+```
+
+**Result:** Peak detection now operates on the complete merged distribution,
+correctly identifying the Z peak at ~91 GeV even for sparse final states.
+
+---
+
+### Fix 7 — Post-processing: use right edge of peak bin (`post_processing_pipeline.py`)
+
+**Problem:** `_find_rightmost_highest_peak` returned `bin_edges[peak_bin_idx]`
+(the **left** edge of the peak bin). With 10 GeV bins, the Z peak bin spans
+81–91 GeV, so the cut kept events from 81 GeV onward — including the full Z peak.
+
+**Fix:** Return `bin_edges[peak_bin_idx + 1]` (the **right** edge):
+
+```python
+# OLD:
+peak_mass = bin_edges[peak_bin_idx]
+# NEW:
+peak_mass = bin_edges[peak_bin_idx + 1]
+```
+
+**Result:** The full Z peak bin (e.g. 81–91 GeV) is now removed, producing
+a smooth falling distribution starting at ~91 GeV suitable for BumpNet.
+
+---
+
+### Fix 8 — Post-processing: periodic SQLite commits (`post_processing_pipeline.py`)
+
+**Problem:** The original code called `writer.commit()` only once after processing
+all signatures. With 3.7M signatures this produced an 8 GB SQLite WAL file that
+was rolled back entirely on job kill — losing all progress.
+
+**Fix:** Commit every 1000 signatures:
+
+```python
+COMMIT_EVERY = 1000
+processed = 0
+for fs_im_key in sorted(fs_im_groups.keys()):
+    # ... process ...
+    processed += 1
+    if processed % COMMIT_EVERY == 0:
+        writer.commit()
+        logger.info(f"Post-processing progress: {processed}/{len(fs_im_groups)} signatures committed")
+writer.commit()  # final commit for remainder
+```
+
+**Result:** WAL stays small (~few MB), and at most 1000 signatures worth of work
+is lost on job kill.
+
+---
+
 ### Fix 1 — Index-based IM naming (`im_pipeline.py`, `histograms_pipeline.py`)
 
 **Problem:** The pipeline used count-based naming for invariant mass combinations,
@@ -113,37 +226,44 @@ Main config for the ATLAS Open Data BumpNet run. Key settings:
 Submits a single PBS job that runs **only the parsing stage**.
 Mass calculation is intentionally excluded to prevent memory explosion.
 
-Usage:
-```bash
-bash submit_parsing_only.sh
-# prints RUN_DIR when submitted — use it for mass calculation step
-```
-
-After parsing completes:
-```bash
-RUN_DIR=/path/to/run_dir bash submit_mass_calc.sh
-```
-
 ### `submit_mass_calc.sh`
 Submits one PBS job **per parsed ROOT chunk** for mass calculation.
 Each job processes exactly one ~2 GB chunk, keeping memory under 16 GB.
 A dependent post-processing + histogram job is submitted automatically
 after all chunk jobs complete.
 
+### `submit_mass_postproc.sh`
+Submits mass calculation array job + dependent post-processing + histogram
+creation job for an **existing** parsed data directory (no re-parsing).
+
 Usage:
 ```bash
-# Use default RUN_DIR (hardcoded in script):
-bash submit_mass_calc.sh
-
-# Or override RUN_DIR:
-RUN_DIR=/path/to/run_dir bash submit_mass_calc.sh
+RUN_DIR=/path/to/existing/run bash submit_mass_postproc.sh
 ```
 
-Key settings per job:
-- `io=31` (measured with `iothrottle -v -l 0`)
-- `walltime=00:15:00` (one chunk takes ~52 seconds)
-- `mem=16gb`
-- `use_multiprocessing: false`, `parallel_processes: 1`
+### `submit_hist_asNeta.sh`
+Submits histogram creation only from existing processed SQLite files.
+Bypasses mass calculation and post-processing.
+
+### `submit_minEvt10.sh`
+Full pipeline submission for `min_events_per_fs=10` run, reusing existing
+parsed data. Handles data and MC separately to avoid SQLite locking conflicts.
+No `hadd` — histogram creation reads all SQLite files in one job.
+
+### `configAsNeta.yaml`
+Config matching Neta's parsing settings (25 MeV cuts, min_events=100).
+
+### `configWmaxTotal.yaml`
+Config with `max_total_particles_in_combination: 4`, `min_particles: 1`.
+
+### `configWmaxTotal_up4j.yaml`
+Config with `jets: max: 4`, `parse_mc: true` for data+MC runs.
+
+### `configWmaxTotal_up4j_minEvt10.yaml`
+Config with `min_events_per_fs: 10` to recover rare electron final states.
+
+### `env.sh`
+Environment setup script for the pipeline (LCG view + atlasenv activation).
 
 ---
 
@@ -162,8 +282,10 @@ Raw PHYSLITE files (CERN EOS, streamed via XRootD)
   - Converts MeV → GeV via _convert_array_to_gev() × 1e-3
   - Writes im_arrays/im_batch_{N}.sqlite
          ↓
-  PostProcessingHandler
-  - Removes known SM resonance peaks (Z, W)
+  PostProcessingHandler  (FIXED: merge by FS_IM key, right edge cut)
+  - Groups all chunks for same FS_IM key, merges before peak detection
+  - Removes Z peak using right edge of peak bin
+  - Periodic commits every 1000 signatures
   - Splits into main / outlier arrays
          ↓
   HistogramCreationHandler
@@ -175,7 +297,7 @@ Raw PHYSLITE files (CERN EOS, streamed via XRootD)
 
 ## Known Issues / Pending Work
 
-### Sub-leading particle combinations (Fix 2 — not yet implemented)
+### Sub-leading particle combinations (not yet implemented)
 The current code always selects leading particles (highest pT) for each
 combination. `{"Electrons": 1}` always means e₀ (leading electron).
 There is no mechanism to compute e₁+j₀ (sub-leading electron + leading jet)
@@ -186,19 +308,24 @@ Files to modify: `services/calculations/combinatorics.py`,
 `services/pipelines/mass_calculation_handler.py`
 
 ### Electron isolation cuts (not yet implemented)
-The electron validation plot shows a flat tail from 1000–5000 GeV due to
-the absence of isolation cuts. Standard ATLAS isolation requirements:
+Without isolation cuts, fake electrons from jets dominate the electron
+channel. The `2ex_0mx_1jx_0gx` final state has only ~1 event across
+all 524 data chunks because real Z→ee+1j events are buried under
+high-multiplicity fake-electron final states. Standard ATLAS isolation:
 - `ptvarcone30_Nonprompt_All_MaxWeightTTVALooseCone_pt1000 / pt < 0.06`
 - `topoetcone20 / pt < 0.06`
 
-These branches are available in PHYSLITE and need to be added to the
-parsing stage `filter_events_by_kinematics`.
+### SM background MC not available for 2024r-pp
+The `2024r-pp_mc` release via atlasopenmagic contains only BSM signal
+samples (Z', W', graviton — DSIDs 301xxx). No SM background MC (Z+jets,
+tt̄, W+jets, QCD) is available for the Run 3 open data release.
+Confirmed with ATLAS Open Data support.
 
-### Z peak removal for multi-body final states
-`_find_rightmost_highest_peak` fails for 3-body distributions (e.g. μ₀+μ₁+j₀)
-where the highest bin is the low-mass turn-on, not the Z+jet peak at ~117 GeV.
-BumpNet flags this as a 5σ excess. The peak removal algorithm needs to be
-updated for multi-body final states.
+### _split_by_first_empty_bin truncates sparse distributions
+For final states with low statistics (e.g. 2μ+1j), the first empty bin
+occurs early in the high-mass tail, causing the postproc histogram to
+be truncated. Use `exclude_outliers: false` in histogram creation to
+include the full distribution above the Z peak cut.
 
 ---
 
@@ -206,5 +333,5 @@ updated for multi-body final states.
 
 - ATLAS Open Data 2024r-pp release: 70,201 files, ~65 TB
 - pT stored in MeV in all PHYSLITE branches
-
----
+- `2024r-pp_mc`: 14,581 files — BSM signal samples only (not SM background)
+- Luminosity: data ~140 fb⁻¹ (Run 3), MC weighted to match

--- a/config.yaml
+++ b/config.yaml
@@ -34,13 +34,13 @@ paths:
 
 # ===NAMES====================================================================
 names:
-  run_name:           &run_name           "atlas_full_120"
+  run_name:           &run_name           "atlas_full_fixComb_fixCut"
   histogram_filename: &histogram_filename "atlas_opendata_full_bumpnet.root"
 
 # ===RUN METADATA=============================================================
 run_metadata:
   run_name: *run_name
-  base_output_dir: "/storage/agrp/netalev/data"
+  base_output_dir: "/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data"
   batch_job_index: null                  # set by submit.sh (--batch-job-index)
   total_batch_jobs: null                 # set by submit.sh (--total-batch-jobs)
 
@@ -82,9 +82,9 @@ parsing_task_config:
   # ===PERFORMANCE===
   use_multiprocessing: false
   parallel_processes: 4
-  threads: 8
+  threads: 2
   env_threshold_memory_mb: 8000
-  chunk_yield_threshold_bytes: 2147483648  # 2 GB
+  chunk_yield_threshold_bytes: 268435456  # 256MB instead of 2GB 2147483648  # 2 GB
   count_retries_failed_files: 3
   fetching_metadata_timeout: 60
   max_files_to_process: null             # null = all files; set e.g. 3 for a quick test
@@ -100,36 +100,37 @@ parsing_task_config:
 
   # ===EVENT FILTERING===
   particle_counts:
-    electrons: { min: 1, max: 4 }
+    electrons: { min: 0, max: 4 }
     muons:     { min: 0, max: 4 }
-    jets:      { min: 0, max: 10 }
+    jets:      { min: 0, max: 4 }
     photons:   { min: 0, max: 4 }
 
   kinematic_cuts:
-    electrons: { pt_min: 25.0, eta_max: 2.47 }
-    muons:     { pt_min: 25.0, eta_max: 2.5 }
-    jets:      { pt_min: 30.0, eta_max: 4.5 }
-    photons:   { pt_min: 25.0, eta_max: 2.37 }
+    electrons: { pt_min: 25000.0, eta_max: 2.47 } #pt in MeV
+    muons:     { pt_min: 25000.0, eta_max: 2.5 }
+    jets:      { pt_min: 30000.0, eta_max: 4.5 }
+    photons:   { pt_min: 25000.0, eta_max: 2.37 }
 
 # --- 2. Mass Calculation -----------------------------------------------------
 # Computes invariant masses for every valid particle combination per final state.
 mass_calculation_task_config:
   # ===PATHS===
-  input_dir:  "/storage/agrp/netalev/data/atlas_pp_root_files"
+  # input_dir:  "/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_pp_root_files"
+  input_dir:  "/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_full_fixComb_fixCut_20260403_230628/parsed_data"
   output_dir: *im_arrays_path
 
   # ===PROCESSING===
   field_to_slice_by: "pt"
-  use_multiprocessing: true
-  parallel_processes: 4
-  fs_chunk_threshold_bytes: 2000000000  # 2 GB
+  use_multiprocessing: false #true
+  parallel_processes: 1 #4
+  fs_chunk_threshold_bytes: 500000000 #2000000000  # 2 GB
 
   # ===COMBINATORICS===
   objects_to_calculate: [Electrons, Muons, Jets, Photons]
   min_particles_in_combination: 2        # min particle types in a combination
-  max_particles_in_combination: 4        # max particle types
+  max_particles_in_combination: 4        # max particle types was 4 reduces 12,567 → ~28 combinations
   min_count_particle_in_combination: 1   # min count per type
-  max_count_particle_in_combination: 4   # max count per type
+  max_count_particle_in_combination: 4   # max count per type was 4
   min_events_per_fs: 100                 # drop final states with fewer events
 
 # --- 3. Post-Processing ------------------------------------------------------
@@ -140,7 +141,7 @@ post_processing_task_config:
   output_dir: *im_arrays_processed_path
 
   # ===PROCESSING===
-  peak_detection_bin_width_gev: 10.0
+  peak_detection_bin_width_gev: 10.0 
 
 # --- 4. Histogram Creation ---------------------------------------------------
 # Builds ROOT histograms from processed invariant-mass arrays.

--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ run_metadata:
 # Enable / disable pipeline stages.  Stages run in order:
 #   parsing → mass_calculating → post_processing → histogram_creation
 tasks:
-  do_parsing: false
+  do_parsing: true
   do_mass_calculating: true
   do_post_processing: true
   do_histogram_creation: true
@@ -82,9 +82,9 @@ parsing_task_config:
   # ===PERFORMANCE===
   use_multiprocessing: false
   parallel_processes: 4
-  threads: 2
+  threads: 8
   env_threshold_memory_mb: 8000
-  chunk_yield_threshold_bytes: 268435456  # 256MB instead of 2GB 2147483648  # 2 GB
+  chunk_yield_threshold_bytes:  2147483648  # 2 GB
   count_retries_failed_files: 3
   fetching_metadata_timeout: 60
   max_files_to_process: null             # null = all files; set e.g. 3 for a quick test
@@ -115,15 +115,14 @@ parsing_task_config:
 # Computes invariant masses for every valid particle combination per final state.
 mass_calculation_task_config:
   # ===PATHS===
-  # input_dir:  "/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_pp_root_files"
-  input_dir:  "/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_full_fixComb_fixCut_20260403_230628/parsed_data"
+  input_dir:  "/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_pp_root_files"
   output_dir: *im_arrays_path
 
   # ===PROCESSING===
   field_to_slice_by: "pt"
-  use_multiprocessing: false #true
-  parallel_processes: 1 #4
-  fs_chunk_threshold_bytes: 500000000 #2000000000  # 2 GB
+  use_multiprocessing: true
+  parallel_processes: 4
+  fs_chunk_threshold_bytes: 2000000000  # 2 GB
 
   # ===COMBINATORICS===
   objects_to_calculate: [Electrons, Muons, Jets, Photons]

--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,7 @@ names:
 # ===RUN METADATA=============================================================
 run_metadata:
   run_name: *run_name
-  base_output_dir: "/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data"
+  base_output_dir: "/data"
   batch_job_index: null                  # set by submit.sh (--batch-job-index)
   total_batch_jobs: null                 # set by submit.sh (--total-batch-jobs)
 
@@ -115,7 +115,7 @@ parsing_task_config:
 # Computes invariant masses for every valid particle combination per final state.
 mass_calculation_task_config:
   # ===PATHS===
-  input_dir:  "/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_pp_root_files"
+  input_dir:  "/data/atlas_pp_root_files"
   output_dir: *im_arrays_path
 
   # ===PROCESSING===
@@ -130,7 +130,10 @@ mass_calculation_task_config:
   max_particles_in_combination: 4        # max particle types was 4 reduces 12,567 → ~28 combinations
   min_count_particle_in_combination: 1   # min count per type
   max_count_particle_in_combination: 4   # max count per type was 4
+  max_total_particles_in_combination: 4
   min_events_per_fs: 100                 # drop final states with fewer events
+  include_subleading: false        # set true to include e1, j1, etc.
+  max_subleading_index: 1          # highest rank index to consider
 
 # --- 3. Post-Processing ------------------------------------------------------
 # Removes known-mass peaks and splits into main / outlier arrays.
@@ -155,5 +158,5 @@ histogram_creation_task_config:
   # ===OUTPUT===
   single_output_file: true
   output_filename: *histogram_filename
-  exclude_outliers: true
+  exclude_outliers: false # was designed to remove high-mass outliers from very broad distributions, but it doesn't work properly during merging
   use_bumpnet_naming: true               # mass_<combo>_cat_<final_state> format

--- a/configWmaxTotal_up4j_minEvt100_subleading.yaml
+++ b/configWmaxTotal_up4j_minEvt100_subleading.yaml
@@ -1,0 +1,100 @@
+# ============================================================================
+# ATLAS Open Data Pipeline — Configuration
+
+# ============================================================================
+
+paths:
+  parsed_data_path:        &parsed_data_path        "./output/parsed_data"
+  im_arrays_path:          &im_arrays_path          "./output/im_arrays"
+  im_arrays_processed_path: &im_arrays_processed_path "./output/im_arrays_processed"
+  histograms_path:         &histograms_path         "./output/histograms"
+  metadata_cache_path:     &metadata_cache_path     "./output/metadata_cache.json"
+  jobs_logs_path:          &jobs_logs_path          "./output/logs"
+
+names:
+  run_name:           &run_name           "atlas_minEvt100_maxTot4_up4j_sublead"
+  histogram_filename: &histogram_filename "atlas_opendata_minEvt100_maxTot4_up4j_sublead_bumpnet.root"
+
+run_metadata:
+  run_name: *run_name
+  base_output_dir: "/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data"
+  batch_job_index: null
+  total_batch_jobs: null
+
+tasks:
+  do_parsing: true 
+  do_mass_calculating: true
+  do_post_processing: true
+  do_histogram_creation: true
+
+testing_config:
+  is_on: false
+  test_run_index: null
+  testing_jobs_path: "./testing_jobs"
+  limit_files_per_year: null
+  limit_combinations: null
+
+parsing_task_config:
+  output_path:    *parsed_data_path
+  file_urls_path: *metadata_cache_path
+  jobs_logs_path: *jobs_logs_path
+  release_years:
+    - "2024r-pp"
+  specific_record_ids: null
+  parse_mc: false
+  use_multiprocessing: false
+  parallel_processes: 4
+  threads: 8
+  env_threshold_memory_mb: 8000
+  chunk_yield_threshold_bytes: 2147483648
+  count_retries_failed_files: 3
+  fetching_metadata_timeout: 60
+  max_files_to_process: 3
+  possible_data_tree_names:
+    - "CollectionTree"
+    - "mini"
+    - "analysis"
+    - "Events"
+  create_dirs: true
+  show_progress_bar: true
+  particle_counts:
+    electrons: { min: 0, max: 4 }
+    muons:     { min: 0, max: 4 }
+    jets:      { min: 0, max: 4 }
+    photons:   { min: 0, max: 4 }
+  kinematic_cuts:
+    electrons: { pt_min: 25000.0, eta_max: 2.47 }
+    muons:     { pt_min: 25000.0, eta_max: 2.5 }
+    jets:      { pt_min: 30000.0, eta_max: 4.5 }
+    photons:   { pt_min: 25000.0, eta_max: 2.37 }
+
+mass_calculation_task_config:
+  input_dir: *parsed_data_path
+  output_dir: *im_arrays_path
+  field_to_slice_by: "pt"
+  use_multiprocessing: true
+  parallel_processes: 4
+  fs_chunk_threshold_bytes: 2000000000
+  objects_to_calculate: [Electrons, Muons, Jets, Photons]
+  min_particles_in_combination: 1
+  max_particles_in_combination: 4
+  min_count_particle_in_combination: 1
+  max_count_particle_in_combination: 4
+  max_total_particles_in_combination: 4
+  min_events_per_fs: 100                  
+  include_subleading: true        # set true to include e1, j1, etc.
+  max_subleading_index: 1          # highest rank index to consider
+
+post_processing_task_config:
+  input_dir:  *im_arrays_path
+  output_dir: *im_arrays_processed_path
+  peak_detection_bin_width_gev: 10.0
+
+histogram_creation_task_config:
+  input_dir:  *im_arrays_processed_path
+  output_dir: *histograms_path
+  bin_width_gev: 10.0
+  single_output_file: true
+  output_filename: *histogram_filename
+  exclude_outliers: true # was designed to remove high-mass outliers from very broad distributions, but it doesn't work properly during merging
+  use_bumpnet_naming: true

--- a/domain/config.py
+++ b/domain/config.py
@@ -167,6 +167,13 @@ class HistogramCreationConfig:
     exclude_outliers: bool = True  # Whether to exclude outlier histograms
     use_bumpnet_naming: bool = False  # When true, use mass_<combo>_cat_<final_state> naming
     
+    # Global ranges (set automatically by update_config_paths_with_run_dir)
+    global_ranges_path: Optional[str] = None
+
+    # Pre-postproc histograms
+    also_save_pre_postproc: bool = False
+    pre_postproc_filename: Optional[str] = None
+
     def __post_init__(self):
         """Validate histogram creation configuration."""
         if not self.input_dir:
@@ -327,6 +334,9 @@ class PipelineConfig:
                 output_filename=hist_dict.get("output_filename"),
                 exclude_outliers=hist_dict.get("exclude_outliers", True),
                 use_bumpnet_naming=hist_dict.get("use_bumpnet_naming", False),
+                global_ranges_path=hist_dict.get("global_ranges_path"),         
+                also_save_pre_postproc=hist_dict.get("also_save_pre_postproc", False), 
+                pre_postproc_filename=hist_dict.get("pre_postproc_filename"), 
             )
         
         # Parse run metadata

--- a/domain/config.py
+++ b/domain/config.py
@@ -94,6 +94,7 @@ class MassCalculationConfig:
     max_particles_in_combination: int = 4
     min_count_particle_in_combination: int = 2
     max_count_particle_in_combination: int = 4
+    max_total_particles_in_combination: int = 4
     min_events_per_fs: int = 100  # Minimum events for a final state to be kept
     
     def __post_init__(self):
@@ -296,6 +297,7 @@ class PipelineConfig:
                 max_particles_in_combination=mass_dict.get("max_particles_in_combination", 4),
                 min_count_particle_in_combination=mass_dict.get("min_count_particle_in_combination", 2),
                 max_count_particle_in_combination=mass_dict.get("max_count_particle_in_combination", 4),
+                max_total_particles_in_combination=mass_dict.get("max_total_particles_in_combination", 4),
                 min_events_per_fs=mass_dict.get("min_events_per_fs", 100),
             )
         

--- a/domain/config.py
+++ b/domain/config.py
@@ -96,6 +96,8 @@ class MassCalculationConfig:
     max_count_particle_in_combination: int = 4
     max_total_particles_in_combination: int = 4
     min_events_per_fs: int = 100  # Minimum events for a final state to be kept
+    include_subleading: bool = False       # set True to include e1, j1, etc.
+    max_subleading_index: int = 1          # highest rank index to consider
     
     def __post_init__(self):
         """Validate mass calculation configuration."""
@@ -299,6 +301,8 @@ class PipelineConfig:
                 max_count_particle_in_combination=mass_dict.get("max_count_particle_in_combination", 4),
                 max_total_particles_in_combination=mass_dict.get("max_total_particles_in_combination", 4),
                 min_events_per_fs=mass_dict.get("min_events_per_fs", 100),
+                include_subleading=mass_dict.get("include_subleading", False),
+                max_subleading_index=mass_dict.get("max_subleading_index", 1),
             )
         
         # Parse post-processing config if enabled

--- a/main.py
+++ b/main.py
@@ -137,6 +137,10 @@ def parse_args():
         parser.error("--run-dir is required when --plots-only or --merge-only is set")
     if args.plots_only and args.merge_only:
         parser.error("--plots-only and --merge-only are mutually exclusive")
+    if args.scan_only and args.merge_only:
+        parser.error("--scan-only and --merge-only are mutually exclusive")
+    if args.scan_only and args.plots_only:
+        parser.error("--scan-only and --plots-only are mutually exclusive")
 
     return args
 
@@ -242,7 +246,8 @@ def main():
         if args.batch_job_index is not None:
             hist_cfg = config_dict.get("histogram_creation_task_config", {})
             hist_cfg["output_filename"] = f"batch_{args.batch_job_index}.root"
-
+            hist_cfg["batch_job_index"] = args.batch_job_index
+            hist_cfg["total_batch_jobs"] = args.total_batch_jobs
         # Create validated config
         config = PipelineConfig.from_dict(config_dict)
         logger.info("Configuration loaded and validated successfully")

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ Supports:
   - Per-stage input override via absolute paths in config.yaml
   - Merge-only mode via --merge-only --run-dir <path>
   - Post-run plot regeneration via --plots-only --run-dir <path>
+  - MC/data separation via --parse-mc true/false
 """
 
 import sys
@@ -95,6 +96,10 @@ def parse_args():
         "--run-dir", type=str, default=None,
         help="Pre-created shared run directory (skips timestamped dir creation)"
     )
+    batch_group.add_argument(
+        "--parse-mc", type=str, default=None, choices=["true", "false"],
+        help="Override parse_mc from config (true/false)"
+    )
 
     # --- Task override ---
     batch_group.add_argument(
@@ -107,6 +112,10 @@ def parse_args():
     # --- Post-run options ---
     post_group = parser.add_argument_group("Post-Run Options")
     post_group.add_argument(
+        "--scan-only", action="store_true",
+        help="Pre-scan processed arrays to compute global histogram ranges"
+    )
+    post_group.add_argument(
         "--merge-only", action="store_true",
         help="Merge batch outputs: hadd histograms + aggregate stats + generate plots"
     )
@@ -118,6 +127,8 @@ def parse_args():
     args = parser.parse_args()
 
     # Validation
+    if args.scan_only and args.run_dir is None:
+        parser.error("--run-dir is required when --scan-only is set")
     if args.batch_job_index is not None and args.total_batch_jobs is None:
         parser.error("--total-batch-jobs is required when --batch-job-index is set")
     if args.total_batch_jobs is not None and args.batch_job_index is None:
@@ -170,6 +181,19 @@ def main():
             return 0
 
         # ------------------------------------------------------------------
+        # SCAN-ONLY MODE: compute global histogram ranges
+        # ------------------------------------------------------------------
+        if args.scan_only:
+            logger.info(f"Scan-only mode: computing global ranges from {args.run_dir}")
+            config_dict = load_config(args.config)
+            config_dict = update_config_paths_with_run_dir(config_dict, args.run_dir)
+            config = PipelineConfig.from_dict(config_dict)
+            executor = PipelineExecutor(config)
+            executor.scan_global_ranges(args.run_dir)
+            logger.info("✓ Global ranges computed successfully")
+            return 0
+        
+        # ------------------------------------------------------------------
         # NORMAL / BATCH PIPELINE MODE
         # ------------------------------------------------------------------
         logger.info(f"Loading configuration from: {args.config}")
@@ -181,6 +205,11 @@ def main():
             config_dict["run_metadata"]["batch_job_index"] = args.batch_job_index
             config_dict["run_metadata"]["total_batch_jobs"] = args.total_batch_jobs
 
+        # Override parse_mc from CLI
+        if args.parse_mc is not None:
+            config_dict.setdefault("parsing_task_config", {})
+            config_dict["parsing_task_config"]["parse_mc"] = args.parse_mc == "true"
+            logger.info(f"parse_mc override from CLI: {args.parse_mc}")
         # Override task toggles from CLI (--tasks flag)
         if args.tasks:
             valid_tasks = {"parsing", "mass_calculating", "post_processing", "histogram_creation"}

--- a/orchestration/handlers/fetch_metadata_handler.py
+++ b/orchestration/handlers/fetch_metadata_handler.py
@@ -1,90 +1,127 @@
 """
 FetchMetadataHandler - Handles metadata fetching state.
-
 Fetches file URLs from ATLAS Open Data API.
 """
-
 from orchestration.context import PipelineContext
 from orchestration.states import PipelineState
 from .base import StateHandler
-from services.metadata.fetcher import MetadataFetcher
+from services.metadata.fetcher import MetadataFetcher, _classify_url, UrlType
 from services.metadata.cache import MetadataCache
 
 
 class FetchMetadataHandler(StateHandler):
-    """
-    Handler for FETCHING_METADATA state.
-    
-    Fetches file metadata from ATLAS API and caches it.
-    """
-    
+
     def __init__(
         self,
         metadata_fetcher: MetadataFetcher,
         metadata_cache: MetadataCache
     ):
-        """
-        Initialize handler.
-        
-        Args:
-            metadata_fetcher: Metadata fetcher service
-            metadata_cache: Metadata cache service
-        """
         super().__init__()
         self.fetcher = metadata_fetcher
         self.cache = metadata_cache
-    
+
     def handle(self, context: PipelineContext) -> tuple[PipelineContext, PipelineState]:
-        """
-        Fetch metadata and determine next state.
-        
-        Args:
-            context: Current pipeline context
-            
-        Returns:
-            Tuple of (updated_context, next_state)
-        """
         self._log_state_entry(context)
-        
+
         parsing_config = context.config.parsing_config
         if not parsing_config:
-            # Skip if no parsing config
             next_state = self._determine_next_state(context)
             self._log_state_exit(context, next_state)
             return context, next_state
-        
-        # Try to load from cache first
+
         metadata = self.cache.load()
-        
+
         if metadata:
             self.logger.info(f"Loaded metadata from cache: {self.cache.cache_path}")
+
+            # ── CHANGE 6: Validate cache integrity before using it ────────────
+            # BEFORE: cache was used immediately after loading with no checks.
+            # A cache built with parse_mc=False contains MC urls in data keys,
+            # which causes MC events to be parsed as collision data silently.
+            #
+            # AFTER: validate and abort with a clear error if contaminated.
+            self._validate_cache_or_abort(metadata)
+            # ── END CHANGE 6 ─────────────────────────────────────────────────
+
         else:
             self.logger.info("Cache miss, fetching metadata from API...")
-            
-            # Fetch fresh metadata
+
+            # ── CHANGE 7: Remove `separate_mc` argument from fetcher call ─────
+            # BEFORE:
+            #     metadata = self.fetcher.fetch(
+            #         release_years=...,
+            #         record_ids=...,
+            #         separate_mc=parsing_config.parse_mc   # <-- removed
+            #     )
+            # AFTER: separation always happens inside fetcher.fetch()
             metadata = self.fetcher.fetch(
                 release_years=list(parsing_config.release_years) if parsing_config.release_years else None,
                 record_ids=list(parsing_config.specific_record_ids) if parsing_config.specific_record_ids else None,
-                separate_mc=parsing_config.parse_mc
             )
-            
-            # Save to cache
+            # ── END CHANGE 7 ─────────────────────────────────────────────────
+
             try:
                 self.cache.save(metadata)
             except TimeoutError as e:
                 self.logger.warning(f"Could not save to cache: {e}")
-        
-        # Log summary
+
         total_files = sum(len(urls) for urls in metadata.values())
         self.logger.info(
             f"Fetched metadata: {len(metadata)} release year(s), {total_files} total files"
         )
-        
-        # Update context
+
         updated_context = context.with_metadata(metadata)
-        
-        # Determine next state
         next_state = self._determine_next_state(updated_context)
-        
         self._log_state_exit(context, next_state)
         return updated_context, next_state
+
+    # ── CHANGE 8: Add cache validation method ────────────────────────────────
+    def _validate_cache_or_abort(self, metadata: dict) -> None:
+        """
+        Validate that no MC URLs are in data keys and vice versa.
+
+        Raises RuntimeError with a clear message if contamination is found,
+        rather than silently proceeding with bad data.
+
+        To fix a contaminated cache: delete the cache file and re-run.
+        The fetcher will rebuild it correctly with the patched _separate_mc_files.
+        """
+        contaminated_keys = []
+
+        for key, urls in metadata.items():
+            is_mc_key = key.endswith("_mc")
+            for url in urls:
+                try:
+                    url_type = _classify_url(url)
+                except ValueError:
+                    contaminated_keys.append(
+                        f"  Key '{key}': unclassifiable URL: {url}"
+                    )
+                    continue
+
+                if is_mc_key and url_type != UrlType.MC:
+                    contaminated_keys.append(
+                        f"  Key '{key}' (MC key): contains DATA url: {url}"
+                    )
+                elif not is_mc_key and url_type != UrlType.DATA:
+                    contaminated_keys.append(
+                        f"  Key '{key}' (data key): contains MC url: {url}"
+                    )
+
+                # Stop scanning after first 5 violations — enough to diagnose
+                if len(contaminated_keys) >= 5:
+                    break
+            if len(contaminated_keys) >= 5:
+                break
+
+        if contaminated_keys:
+            raise RuntimeError(
+                f"Contaminated metadata cache detected at: {self.cache.cache_path}\n"
+                f"MC and data URLs are mixed. This cache was built with parse_mc=False.\n"
+                f"Fix: delete the cache file and re-run to rebuild it.\n"
+                f"First violations found:\n"
+                + "\n".join(contaminated_keys)
+            )
+
+        self.logger.info("Cache integrity check passed — no cross-contamination.")
+    # ── END CHANGE 8 ─────────────────────────────────────────────────────────

--- a/orchestration/handlers/histogram_creation_handler.py
+++ b/orchestration/handlers/histogram_creation_handler.py
@@ -39,6 +39,8 @@ class HistogramCreationHandler(StateHandler):
             "exclude_outliers": hc.exclude_outliers,
             "use_bumpnet_naming": hc.use_bumpnet_naming,
             "batch_job_index": context.config.batch_job_index,
+            "total_batch_jobs": context.config.total_batch_jobs,
+            "global_ranges_path": getattr(hc, 'global_ranges_path', None),
         }
 
         # If the previous stage produced files, pass them explicitly

--- a/orchestration/handlers/mass_calculation_handler.py
+++ b/orchestration/handlers/mass_calculation_handler.py
@@ -53,6 +53,7 @@ class MassCalculationHandler(StateHandler):
             max_particles=mc.max_particles_in_combination,
             min_count=mc.min_count_particle_in_combination,
             max_count=mc.max_count_particle_in_combination,
+            max_total_particles=mc.max_total_particles_in_combination,
         )
         self.logger.info(f"Generated {len(all_combinations)} combinations to process")
 

--- a/orchestration/handlers/mass_calculation_handler.py
+++ b/orchestration/handlers/mass_calculation_handler.py
@@ -78,31 +78,32 @@ class MassCalculationHandler(StateHandler):
         parsed_dir = Path(mc.input_dir)
         if context.parsed_files:
             root_files = [Path(f) for f in context.parsed_files if Path(f).exists()]
+            self.logger.info(
+                f"Using {len(root_files)} file(s) from parsing stage context"
+            )
+            # Parsing already assigned the correct files — no further splitting needed
         else:
             root_files = sorted(parsed_dir.glob("*.root"))
+            self.logger.info(
+                f"No context files — reading {len(root_files)} file(s) from {parsed_dir}"
+            )
+            # Apply batch splitting only when reading from disk
+            batch_idx = context.config.batch_job_index
+            total_batches = context.config.total_batch_jobs
+            if batch_idx is not None and total_batches is not None:
+                total_files = len(root_files)
+                chunk_size = max(1, total_files // total_batches)
+                slice_start = (batch_idx - 1) * chunk_size
+                slice_end = total_files if batch_idx == total_batches else slice_start + chunk_size
+                root_files = root_files[slice_start:slice_end]
+                self.logger.info(
+                    f"Batch {batch_idx}/{total_batches}: "
+                    f"processing files {slice_start+1}-{slice_end} of {total_files}"
+                )
 
         if not root_files:
             self.logger.warning(f"No parsed ROOT files found in {parsed_dir}")
             return context, self._determine_next_state(context)
-
-        # ── Apply batch splitting if configured ──
-        batch_idx = context.config.batch_job_index
-        total_batches = context.config.total_batch_jobs
-
-        if batch_idx is not None and total_batches is not None:
-            total_files = len(root_files)
-            chunk_size = total_files // total_batches
-            slice_start = (batch_idx - 1) * chunk_size
-            slice_end = total_files if batch_idx == total_batches else slice_start + chunk_size
-            root_files = root_files[slice_start:slice_end]
-            self.logger.info(
-                f"Batch {batch_idx}/{total_batches}: "
-                f"processing files {slice_start+1}-{slice_end} of {total_files}"
-            )
-
-        self.logger.info(
-            f"Processing {len(root_files)} parsed file(s) from {parsed_dir}"
-        )
 
         total_created_chunks = 0
 

--- a/orchestration/handlers/mass_calculation_handler.py
+++ b/orchestration/handlers/mass_calculation_handler.py
@@ -54,6 +54,8 @@ class MassCalculationHandler(StateHandler):
             min_count=mc.min_count_particle_in_combination,
             max_count=mc.max_count_particle_in_combination,
             max_total_particles=mc.max_total_particles_in_combination,
+            include_subleading=getattr(mc, 'include_subleading', False),
+            max_subleading_index=getattr(mc, 'max_subleading_index', 1),
         )
         self.logger.info(f"Generated {len(all_combinations)} combinations to process")
 

--- a/orchestration/handlers/parsing_handler.py
+++ b/orchestration/handlers/parsing_handler.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import uproot
 import awkward as ak
 
+import gc
+
 from orchestration.context import PipelineContext
 from orchestration.states import PipelineState
 from .base import StateHandler
@@ -172,6 +174,8 @@ class ParsingHandler(StateHandler):
                         f"Saved chunk {chunk.chunk_index}: "
                         f"{chunk.event_count} events, {chunk.size_mb:.1f} MB → {file_path}"
                     )
+                    del chunk
+                    gc.collect()
         
         # Flush remaining events
         final_chunk = self.accumulator.flush()
@@ -191,6 +195,8 @@ class ParsingHandler(StateHandler):
             self.logger.info(
                 f"Saved final chunk: {final_chunk.event_count} events, {final_chunk.size_mb:.1f} MB → {file_path}"
             )
+            del final_chunk;
+            gc.collect()
         
         # Create parsing statistics
         end_time = datetime.now()

--- a/orchestration/handlers/parsing_handler.py
+++ b/orchestration/handlers/parsing_handler.py
@@ -133,7 +133,14 @@ class ParsingHandler(StateHandler):
         
         # Parse each release year
         for release_year, file_urls in metadata.items():
-            
+            # ── Skip MC keys when parse_mc=False ─────────────────────────────────────
+            # The fetcher always separates data and MC into separate keys (e.g.
+            # '2024r-pp' and '2024r-pp_mc'). parse_mc controls whether MC is
+            # included in the parsing run, not whether it is separated.
+            if release_year.endswith("_mc") and not parsing_config.parse_mc:
+                self.logger.info(f"Skipping MC key '{release_year}' (parse_mc=False)")
+                continue
+
             self.logger.info(
                 f"Parsing {len(file_urls)} files for release year: {release_year}"
             )

--- a/pipeline/executor.py
+++ b/pipeline/executor.py
@@ -163,9 +163,11 @@ class PipelineExecutor:
                 if result.returncode == 0:
                     self.logger.info(f"hadd succeeded: {merged_path}")
                     # Clean up batch files
+                    archive_dir = Path(hist_dir) / "batch_files_archive"
+                    archive_dir.mkdir(exist_ok=True)
                     for bf in batch_roots:
-                        bf.unlink()
-                        self.logger.debug(f"Removed batch file: {bf}")
+                        bf.rename(archive_dir / bf.name)   
+                        self.logger.debug(f"Archived batch file: {bf.name}")
                 else:
                     self.logger.error(f"hadd failed (rc={result.returncode}): {result.stderr}")
             except FileNotFoundError:
@@ -216,7 +218,7 @@ class PipelineExecutor:
             for key in ("total_events", "successful_files", "failed_files",
                         "total_chunks", "total_size_mb"):
                 if key in p:
-                    parsing_sums[key] = parsing_sums.get(key, 0) + p[key]
+                    parsing_sums[key] = parsing_sums.get(key, 0) + int(float(p[key]))
         if parsing_sums:
             aggregated["parsing_totals"] = parsing_sums
 
@@ -268,8 +270,73 @@ class PipelineExecutor:
 
         return pipeline_stats
 
+    # def _read_parsed_data_stats(self, parsed_dir: str):
+    #     """Read all parsed ROOT files and compute consolidated stats."""
+    #     import uproot
+    #     import numpy as np
+
+    #     if not os.path.isdir(parsed_dir):
+    #         return None, None
+
+    #     root_files = sorted(Path(parsed_dir).glob("*.root"))
+    #     if not root_files:
+    #         return None, None
+
+    #     total_events = 0
+    #     total_size_bytes = 0
+    #     particle_counts = {}      # {type: total_count}
+    #     particle_dists = {}       # {type: [per-event counts]}
+    #     events_per_file = []
+
+    #     for rf in root_files:
+    #         try:
+    #             total_size_bytes += rf.stat().st_size
+    #             with uproot.open(str(rf)) as f:
+    #                 if "events" not in f:
+    #                     continue
+    #                 tree = f["events"]
+    #                 n_events = tree.num_entries
+    #                 total_events += n_events
+    #                 events_per_file.append(n_events)
+
+    #                 # Discover particle branches (nElectrons, nMuons, …)
+    #                 for branch_name in tree.keys():
+    #                     if branch_name.startswith("n") and branch_name != "nEvents":
+    #                         ptype = branch_name[1:]  # e.g. "Electrons"
+    #                         counts = tree[branch_name].array(library="np")
+    #                         total_for_type = int(np.sum(counts))
+    #                         particle_counts[ptype] = particle_counts.get(ptype, 0) + total_for_type
+    #                         if ptype not in particle_dists:
+    #                             particle_dists[ptype] = []
+    #                         particle_dists[ptype].extend(counts.tolist())
+    #         except Exception as e:
+    #             self.logger.warning(f"Could not read {rf}: {e}")
+
+    #     avg_per_file = total_events / len(root_files) if root_files else 0
+
+    #     parsing_stats = {
+    #         'total_files': len(root_files),
+    #         'successful_files': len(root_files),
+    #         'failed_files': 0,
+    #         'total_events': total_events,
+    #         'total_chunks': len(root_files),
+    #         'total_size_mb': total_size_bytes / (1024 * 1024),
+    #         'total_time_sec': 0,   # not available from disk
+    #         'average_events_per_file': avg_per_file,
+    #         'max_memory_mb': 0,
+    #         'timeout_count': 0,
+    #         'error_types': {},
+    #     }
+
+    #     particle_stats = {
+    #         'particle_counts': particle_counts,
+    #         'distributions': particle_dists,
+    #         'events_per_file': events_per_file,
+    #     }
+
+    #     return parsing_stats, particle_stats
+
     def _read_parsed_data_stats(self, parsed_dir: str):
-        """Read all parsed ROOT files and compute consolidated stats."""
         import uproot
         import numpy as np
 
@@ -282,8 +349,7 @@ class PipelineExecutor:
 
         total_events = 0
         total_size_bytes = 0
-        particle_counts = {}      # {type: total_count}
-        particle_dists = {}       # {type: [per-event counts]}
+        particle_counts = {}
         events_per_file = []
 
         for rf in root_files:
@@ -297,18 +363,16 @@ class PipelineExecutor:
                     total_events += n_events
                     events_per_file.append(n_events)
 
-                    # Discover particle branches (nElectrons, nMuons, …)
                     for branch_name in tree.keys():
                         if branch_name.startswith("n") and branch_name != "nEvents":
-                            ptype = branch_name[1:]  # e.g. "Electrons"
+                            ptype = branch_name[1:]
+                            # Only read sum, not full array — avoids memory blowup
                             counts = tree[branch_name].array(library="np")
-                            total_for_type = int(np.sum(counts))
-                            particle_counts[ptype] = particle_counts.get(ptype, 0) + total_for_type
-                            if ptype not in particle_dists:
-                                particle_dists[ptype] = []
-                            particle_dists[ptype].extend(counts.tolist())
+                            particle_counts[ptype] = particle_counts.get(ptype, 0) + int(np.sum(counts))
+                            del counts  # free immediately
             except Exception as e:
                 self.logger.warning(f"Could not read {rf}: {e}")
+
 
         avg_per_file = total_events / len(root_files) if root_files else 0
 
@@ -319,7 +383,7 @@ class PipelineExecutor:
             'total_events': total_events,
             'total_chunks': len(root_files),
             'total_size_mb': total_size_bytes / (1024 * 1024),
-            'total_time_sec': 0,   # not available from disk
+            'total_time_sec': 0,
             'average_events_per_file': avg_per_file,
             'max_memory_mb': 0,
             'timeout_count': 0,
@@ -328,11 +392,11 @@ class PipelineExecutor:
 
         particle_stats = {
             'particle_counts': particle_counts,
-            'distributions': particle_dists,
+            'distributions': {},   # dropped — too large for 671 files
             'events_per_file': events_per_file,
         }
 
-        return parsing_stats, particle_stats
+        return parsing_stats, particle_stats    
 
     def _read_im_array_stats(self, im_dir: str):
         """Read invariant mass array (.npy) files and compute stats.

--- a/pipeline/executor.py
+++ b/pipeline/executor.py
@@ -5,8 +5,11 @@ Wires together all services and executes the state machine.
 Supports consolidated plot generation from output data.
 
 Architecture (multi-job mode):
-  Each batch job runs the full pipeline and saves:
+  Each batch job runs parsing + mass_calc + post_processing and saves:
     - batch_N_stats.json   → logs/
+  The scan job (--scan-only) runs after all batch jobs and saves:
+    - global_ranges.json   → logs/
+  The histogram array jobs run after scan and save:
     - batch_N.root         → histograms/
   The merge job (--merge-only) combines everything via:
     - hadd histograms/batch_*.root → histograms/<output_filename>
@@ -127,6 +130,39 @@ class PipelineExecutor:
 
         self.logger.info(f"Saved batch stats to: {stats_path}")
 
+
+    def scan_global_ranges(self, run_dir: str):
+        """
+        Pre-scan all processed SQLite files to compute global min/max per
+        bumpnet signature. Saves result to logs/global_ranges.json.
+        Must run before histogram creation batches.
+        """
+        from services.pipelines.histograms_pipeline import compute_global_ranges, save_global_ranges
+
+        proc_dir = os.path.join(run_dir, "im_arrays_processed")
+        logs_dir = os.path.join(run_dir, "logs")
+        os.makedirs(logs_dir, exist_ok=True)
+
+        sqlite_files = sorted([
+            f for f in os.listdir(proc_dir) if f.endswith(".sqlite")
+        ])
+        if not sqlite_files:
+            self.logger.error(f"No processed SQLite files found in {proc_dir}")
+            raise RuntimeError(f"No processed SQLite files found in {proc_dir}")
+
+        self.logger.info(f"Scanning {len(sqlite_files)} SQLite files for global ranges...")
+
+        hc = self.config.histogram_creation_config
+        exclude_outliers = hc.exclude_outliers if hc else True
+
+        ranges = compute_global_ranges(sqlite_files, proc_dir, exclude_outliers=exclude_outliers)
+
+        output_path = os.path.join(logs_dir, "global_ranges.json")
+        save_global_ranges(ranges, output_path)
+        self.logger.info(
+            f"Saved global ranges for {len(ranges)} signatures to {output_path}"
+        )
+
     def merge_outputs(self, run_dir: str):
         """
         Merge outputs from all batch jobs:
@@ -180,6 +216,33 @@ class PipelineExecutor:
         else:
             self.logger.info("No batch_*.root files found in histograms/ – skipping hadd")
 
+        
+        # ---- 1b. Optionally also produce pre-postproc histograms ----
+        hc = self.config.histogram_creation_config
+        if hc and getattr(hc, 'also_save_pre_postproc', False):
+            from services.pipelines.histograms_pipeline import create_histograms
+            im_dir = os.path.join(run_dir, "im_arrays")
+            im_sqlite_files = sorted([
+                f for f in os.listdir(im_dir) if f.endswith(".sqlite")
+            ])
+            if im_sqlite_files:
+                self.logger.info("Producing pre-postproc histograms from im_arrays/")
+                nopp_config = {
+                    "input_dir": im_dir,
+                    "output_dir": hist_dir,
+                    "bin_width_gev": hc.bin_width_gev,
+                    "single_output_file": True,
+                    "output_filename": hc.pre_postproc_filename,
+                    "exclude_outliers": False,
+                    "use_bumpnet_naming": hc.use_bumpnet_naming,
+                    "global_ranges_path": os.path.join(
+                        run_dir, "logs", "global_ranges.json"
+                    ),
+                }
+                create_histograms(nopp_config, file_list=im_sqlite_files)
+                self.logger.info(
+                    f"Pre-postproc histograms saved to {hc.pre_postproc_filename}"
+                )
         # ---- 2. Aggregate batch stats ----
         batch_stats_files = sorted(Path(logs_dir).glob("batch_*_stats.json"))
         if batch_stats_files:

--- a/services/calculations/combinatorics.py
+++ b/services/calculations/combinatorics.py
@@ -33,7 +33,9 @@ def get_all_combinations(
         for chosen_types in itertools.combinations(object_types, r):
             count_ranges = [range(min_count, max_count + 1) for _ in chosen_types]
             for counts in itertools.product(*count_ranges):
-                if sum(counts) > max_total_particles:   # ← new filter
+                if sum(counts) > max_total_particles:   #  skip combinations exceeding particle cap
+                    continue
+                if sum(counts) < 2:                     # skip single-particle IM (physically meaningless)
                     continue
                 combo = dict(zip(chosen_types, counts))
                 combo_key = frozenset(combo.items())

--- a/services/calculations/combinatorics.py
+++ b/services/calculations/combinatorics.py
@@ -1,8 +1,41 @@
 """
 Combinatorics for generating particle-type combinations.
+
+Each combination is a dict mapping particle type → (count, start_index).
+For backward compatibility, plain int values are also accepted everywhere
+and are treated as (count, start_index=0).
+
+Examples
+--------
+Leading-only (include_subleading=False, default):
+    {"Electrons": (1, 0), "Jets": (1, 0)}   → e0 + j0
+
+With sub-leading (include_subleading=True):
+    {"Electrons": (1, 0), "Jets": (1, 0)}   → e0 + j0
+    {"Electrons": (1, 1), "Jets": (1, 0)}   → e1 + j0   (sub-leading e)
+    {"Electrons": (1, 0), "Jets": (1, 1)}   → e0 + j1   (sub-leading j)
+    {"Electrons": (1, 1), "Jets": (1, 1)}   → e1 + j1
+
+Helper accessors (safe for both old int and new tuple values):
+    get_count(v)  → number of particles to take
+    get_start(v)  → starting rank index (0 = leading)
 """
 import itertools
-from typing import Dict, List, Iterator
+from typing import Dict, List, Tuple, Union
+
+# Type alias: value in a combination dict is either a plain int (legacy)
+# or a (count, start_index) tuple.
+CombValue = Union[int, Tuple[int, int]]
+
+
+def get_count(value: CombValue) -> int:
+    """Return particle count from a combination value."""
+    return value[0] if isinstance(value, tuple) else value
+
+
+def get_start(value: CombValue) -> int:
+    """Return start rank index from a combination value (0 = leading)."""
+    return value[1] if isinstance(value, tuple) else 0
 
 
 def get_all_combinations(
@@ -12,20 +45,34 @@ def get_all_combinations(
     min_count: int,
     max_count: int,
     max_total_particles: int = 4,
-    limit: int = None
-) -> List[Dict[str, int]]:
+    limit: int = None,
+    include_subleading: bool = False,
+    max_subleading_index: int = 1,
+) -> List[Dict[str, CombValue]]:
     """
     Generate all unique particle combinations.
 
     Args:
-        object_types: particle type names (e.g. ["Electrons", "Muons", ...])
-        min_particles: minimum number of particle *types* in a combination
-        max_particles: maximum number of particle *types* in a combination
-        min_count: minimum count per included type
-        max_count: maximum count per included type
-        max_total_particles: hard cap on total particles across all types
+        object_types:         Particle type names (e.g. ["Electrons", "Muons", ...])
+        min_particles:        Minimum number of particle *types* in a combination.
+        max_particles:        Maximum number of particle *types* in a combination.
+        min_count:            Minimum particle count per included type.
+        max_count:            Maximum particle count per included type.
+        max_total_particles:  Hard cap on total particles across all types.
+        limit:                Optional cap on total combinations returned.
+        include_subleading:   If True, also generate start-index variants so that
+                              sub-leading particles (e₁, j₁, …) are included as
+                              separate signatures.
+        max_subleading_index: Highest start index to consider when
+                              include_subleading=True.  Default 1 means we go up
+                              to the first sub-leading particle (index 1).
+                              Increase to 2 for sub-sub-leading, etc.
+
+    Returns:
+        List of combination dicts.  Each value is a (count, start_index) tuple.
+        start_index=0 for all leading-only combinations.
     """
-    all_combinations: List[Dict[str, int]] = []
+    base_combinations: List[Dict[str, CombValue]] = []
     seen: set = set()
 
     n_types = min(max_particles, len(object_types))
@@ -33,16 +80,67 @@ def get_all_combinations(
         for chosen_types in itertools.combinations(object_types, r):
             count_ranges = [range(min_count, max_count + 1) for _ in chosen_types]
             for counts in itertools.product(*count_ranges):
-                if sum(counts) > max_total_particles:   #  skip combinations exceeding particle cap
+                if sum(counts) > max_total_particles:   # skip combinations exceeding particle cap
                     continue
                 if sum(counts) < 2:                     # skip single-particle IM (physically meaningless)
                     continue
-                combo = dict(zip(chosen_types, counts))
-                combo_key = frozenset(combo.items())
+                # Store as (count, start=0) tuples
+                combo = {ptype: (cnt, 0) for ptype, cnt in zip(chosen_types, counts)}
+                combo_key = frozenset((k, v) for k, v in combo.items())
                 if combo_key not in seen:
                     seen.add(combo_key)
-                    all_combinations.append(combo)
+                    base_combinations.append(combo)
+
+    if not include_subleading:
+        result = base_combinations
+    else:
+        # Pass an empty seen set so _expand_with_subleading always includes
+        # the all-zero (leading) variants alongside the sub-leading ones.
+        result = base_combinations + _expand_with_subleading(
+            base_combinations, max_subleading_index, seen
+        )
 
     if limit is not None:
-        return all_combinations[:limit]
+        return result[:limit]
+    return result
+
+
+def _expand_with_subleading(
+    base_combinations: List[Dict[str, CombValue]],
+    max_subleading_index: int,
+    seen: set,
+) -> List[Dict[str, CombValue]]:
+    """
+    For each base combination, generate all variants where each particle
+    type's start index is independently varied from 0 to max_subleading_index,
+    subject to the constraint that start_index + count ≤ max_subleading_index + 1
+    (i.e. we don't ask for particles beyond what we expect to exist).
+
+    The original (all-zero start) combination is always first.
+    """
+    all_combinations: List[Dict[str, CombValue]] = []
+
+    for combo in base_combinations:
+        particle_types = list(combo.keys())
+
+        # Build list of possible (count, start) values per particle type
+        per_type_variants = []
+        for ptype in particle_types:
+            count, _ = combo[ptype]
+            # start can range from 0 up to max_subleading_index,
+            # but only if start + count - 1 <= max_subleading_index
+            max_start = max_subleading_index - count + 1
+            if max_start < 0:
+                max_start = 0
+            variants = [(count, s) for s in range(0, max_start + 1)]
+            per_type_variants.append(variants)
+
+        # Cartesian product of per-type start choices
+        for value_combo in itertools.product(*per_type_variants):
+            new_combo = dict(zip(particle_types, value_combo))
+            combo_key = frozenset((k, v) for k, v in new_combo.items())
+            if combo_key not in seen:
+                seen.add(combo_key)
+                all_combinations.append(new_combo)
+
     return all_combinations

--- a/services/calculations/combinatorics.py
+++ b/services/calculations/combinatorics.py
@@ -11,6 +11,7 @@ def get_all_combinations(
     max_particles: int,
     min_count: int,
     max_count: int,
+    max_total_particles: int = 4,
     limit: int = None
 ) -> List[Dict[str, int]]:
     """
@@ -22,6 +23,7 @@ def get_all_combinations(
         max_particles: maximum number of particle *types* in a combination
         min_count: minimum count per included type
         max_count: maximum count per included type
+        max_total_particles: hard cap on total particles across all types
     """
     all_combinations: List[Dict[str, int]] = []
     seen: set = set()
@@ -31,6 +33,8 @@ def get_all_combinations(
         for chosen_types in itertools.combinations(object_types, r):
             count_ranges = [range(min_count, max_count + 1) for _ in chosen_types]
             for counts in itertools.product(*count_ranges):
+                if sum(counts) > max_total_particles:   # ← new filter
+                    continue
                 combo = dict(zip(chosen_types, counts))
                 combo_key = frozenset(combo.items())
                 if combo_key not in seen:

--- a/services/calculations/im_calculator.py
+++ b/services/calculations/im_calculator.py
@@ -10,6 +10,7 @@ from typing import Dict, Iterator, List
 from collections import Counter
 
 from services.calculations import consts, physics_calcs
+from services.calculations.combinatorics import get_count, get_start
 
 
 class IMCalculator:
@@ -118,7 +119,14 @@ class IMCalculator:
         return final_state
 
     @staticmethod
-    def does_final_state_contain_combination(final_state: str, combination: Dict[str, int]) -> bool:
+    def does_final_state_contain_combination(final_state: str, combination: Dict) -> bool:
+        """
+        Check whether a final state has enough particles to satisfy a combination.
+
+        For sub-leading combinations the event needs start + count particles
+        of each type, not just count.  Works with both plain-int and
+        (count, start_index) combination values.
+        """
         fs_particles = final_state.split('_')
         for str_amount_particle in fs_particles:
             if len(str_amount_particle) < 2:
@@ -134,8 +142,11 @@ class IMCalculator:
                 continue
 
             fs_particle_amount = int(amount_to_calc)
-            required_amount = combination[particle]
-            if fs_particle_amount < required_amount:
+            value = combination[particle]
+            count = get_count(value)
+            start = get_start(value)
+            # Need at least start + count particles available in this final state
+            if fs_particle_amount < start + count:
                 return False
         return True
 
@@ -148,5 +159,9 @@ class IMCalculator:
         return physics_calcs.filter_events_by_kinematics(events, kinematic_cuts)
 
     def slice_by_field(self, events, particle_counts, field_to_slice_by="pt"):
+        """
+        Slice particle arrays by rank window [start : start + count].
+        Delegates to physics_calcs which handles both int and tuple values.
+        """
         return physics_calcs.slice_events_by_field(
             events, particle_counts, field_to_slice_by)

--- a/services/calculations/physics_calcs.py
+++ b/services/calculations/physics_calcs.py
@@ -11,6 +11,7 @@ import gc
 from typing import Dict, Iterator, Tuple, Optional
 
 from services.calculations import consts
+from services.calculations.combinatorics import get_count, get_start
 
 
 def calc_inv_mass(particle_events: ak.Array) -> ak.Array:
@@ -91,7 +92,11 @@ def limit_particles_in_fs(final_state: str, threshold: int) -> str:
     return final_state
 
 
-def is_finalstate_contain_combination(final_state: str, combination: Dict[str, int]) -> bool:
+def is_finalstate_contain_combination(final_state: str, combination: Dict) -> bool:
+    """
+    Check whether a final state has enough particles to satisfy a combination.
+    Works with both plain-int and (count, start_index) combination values.
+    """
     fs_particles = final_state.split('_')
     for str_amount_particle in fs_particles:
         if len(str_amount_particle) < 2:
@@ -106,18 +111,27 @@ def is_finalstate_contain_combination(final_state: str, combination: Dict[str, i
             continue
 
         fs_particle_amount = int(amount_to_calc)
-        required_amount = combination[particle]
-        if fs_particle_amount < required_amount:
+        value = combination[particle]
+        count = get_count(value)
+        start = get_start(value)
+        # Need at least start + count particles available
+        if fs_particle_amount < start + count:
             return False
     return True
 
 
 def filter_events_by_particle_counts(
     events: ak.Array,
-    particle_counts: Dict[str, int],
+    particle_counts: Dict,
     is_exact_count: bool = False,
     is_particle_counts_range: bool = False
 ) -> ak.Array:
+    """
+    Filter events by particle counts.
+    Accepts both plain-int and (count, start_index) combination values.
+    For sub-leading combinations, filters to events that have at least
+    start + count particles of each required type.
+    """
     if len(events) == 0:
         return events
 
@@ -138,9 +152,18 @@ def filter_events_by_particle_counts(
             range_dict = value
             particle_mask = (obj_count >= range_dict['min']) & (obj_count <= range_dict['max'])
         elif is_exact_count:
-            particle_mask = (obj_count == value)
+            count = get_count(value)
+            start = get_start(value)
+            if start == 0:
+                # leading only: exact count as before
+                particle_mask = (obj_count == count)
+            else:
+                # sub-leading: need at least start + count particles
+                particle_mask = (obj_count >= start + count)
         else:
-            particle_mask = (obj_count >= value)
+            count = get_count(value)
+            start = get_start(value)
+            particle_mask = (obj_count >= start + count)
 
         combined_mask = combined_mask & particle_mask
 
@@ -164,17 +187,31 @@ def filter_events_by_particle_counts(
 
 def slice_events_by_field(
     events: ak.Array,
-    particle_counts: Dict[str, int],
+    particle_counts: Dict,
     field_to_slice_by: str
 ) -> ak.Array:
-    for obj, count in particle_counts.items():
+    """
+    Sort each particle type by field_to_slice_by (descending) and slice
+    out the requested window [start : start + count].
+
+    Works with both plain-int values (start=0) and (count, start_index) tuples.
+
+    Example:
+        particle_counts = {"Electrons": (1, 1), "Jets": (1, 0)}
+        → takes e₁ (second-highest pT electron) and j₀ (leading jet)
+    """
+    for obj, value in particle_counts.items():
         actual_field = find_actual_field_name(events.fields, obj)
         if not actual_field:
             continue
 
+        count = get_count(value)
+        start = get_start(value)
+
         obj_array = events[actual_field]
         sorted_obj_array = obj_array[ak.argsort(obj_array[field_to_slice_by], ascending=False)]
-        sliced_obj_array = sorted_obj_array[:, :count]
+        # Slice window: [start : start + count]
+        sliced_obj_array = sorted_obj_array[:, start : start + count]
         events[actual_field] = sliced_obj_array
 
     return events

--- a/services/metadata/fetcher.py
+++ b/services/metadata/fetcher.py
@@ -6,15 +6,74 @@ Single responsibility: Interact with ATLAS API to get file URLs.
 
 import logging
 import json
+import re
 import requests
 import io
 from contextlib import redirect_stdout
 from concurrent.futures import ThreadPoolExecutor
+from enum import Enum
 from typing import Optional
 import atlasopenmagic as atom
 
 from services import consts
 from domain.metadata import ReleaseMetadata
+
+# Matches the dataset namespace component in ATLAS Open Data URLs.
+# The digit+underscore suffix (e.g. mc20_, data16_) is specific enough
+# to avoid false matches like "opendata" or "metadata".
+# Examples:
+#   MC:   .../mc20_13TeV/DAOD_PHYSLITE.xxx
+#   Data: .../data16_13TeV/DAOD_PHYSLITE.xxx
+
+
+class UrlType(Enum):
+    DATA    = "data"
+    MC      = "mc"
+
+
+_MC_NAMESPACE_RE   = re.compile(r'/mc\d+_',   re.IGNORECASE)
+_DATA_NAMESPACE_RE = re.compile(r'/data\d+_', re.IGNORECASE)
+
+
+def _classify_url(url: str) -> UrlType:
+    """
+    Classify a URL as DATA or MC using anchored regex on the RUCIO namespace.
+
+    Raises ValueError if the URL matches both patterns or neither — so
+    unclassifiable URLs are never silently misrouted.
+    """
+    is_mc   = bool(_MC_NAMESPACE_RE.search(url))
+    is_data = bool(_DATA_NAMESPACE_RE.search(url))
+
+    if is_mc and not is_data:
+        return UrlType.MC
+    if is_data and not is_mc:
+        return UrlType.DATA
+    raise ValueError(
+        f"URL matched {'both' if is_mc and is_data else 'neither'} "
+        f"MC and DATA patterns — cannot classify: {url}"
+    )
+
+
+def _assert_no_cross_contamination(separated: dict[str, list[str]]) -> None:
+    """
+    Post-separation integrity check.
+    Asserts no MC URLs ended up in data keys and vice versa.
+    Raises AssertionError immediately if violated.
+    """
+    for key, urls in separated.items():
+        is_mc_key = key.endswith("_mc")
+        for url in urls:
+            url_type = _classify_url(url)
+            if is_mc_key and url_type != UrlType.MC:
+                raise AssertionError(
+                    f"DATA url found in MC key '{key}': {url}"
+                )
+            if not is_mc_key and url_type != UrlType.DATA:
+                raise AssertionError(
+                    f"MC url found in DATA key '{key}': {url}"
+                )
+# ── END CHANGE 1 ─────────────────────────────────────────────────────────────
 
 
 class MetadataFetcher:
@@ -79,14 +138,16 @@ class MetadataFetcher:
     def fetch_by_release_years(
         self,
         release_years: list[str],
-        separate_mc: bool = False
+      # ── CHANGE 2: Remove `separate_mc` parameter entirely ────────────────
+        # BEFORE: separate_mc: bool = False
+        # AFTER:  parameter removed — separation is always performed.
+        # There is no valid use case for mixing data and MC in the cache.
     ) -> dict[str, list[str]]:
         """
         Fetch file URLs for given release years.
         
         Args:
             release_years: List of release years to fetch
-            separate_mc: Whether to separate MC files from data files
             
         Returns:
             Dict mapping release years to lists of file URLs
@@ -95,10 +156,15 @@ class MetadataFetcher:
         
         release_files = self._fetch_urls_for_releases(release_years)
         
-        if separate_mc:
-            release_files = self._separate_mc_files(release_files)
-        
-        return release_files
+        # ── CHANGE 3: Always separate, remove `if separate_mc` branch ────────
+        # BEFORE:
+        #     if separate_mc:
+        #         release_files = self._separate_mc_files(release_files)
+        #     return release_files
+        #
+        # AFTER: always separate, using strict classifier:
+        return self._separate_mc_files(release_files)
+        # ── END CHANGE 3 ─────────────────────────────────────────────────────
     
     def fetch_by_record_ids(
         self,
@@ -119,8 +185,8 @@ class MetadataFetcher:
         for record_id in record_ids:
             try:
                 file_urls = self._fetch_files_for_record(record_id)
-                record_key = f"record_{record_id}"
-                release_files[record_key] = file_urls
+
+                release_files[f"record_{record_id}"] = file_urls
                 
                 logging.info(f"Fetched {len(file_urls)} files from record {record_id}")
             except Exception as e:
@@ -132,7 +198,10 @@ class MetadataFetcher:
         self,
         release_years: Optional[list[str]] = None,
         record_ids: Optional[list[int]] = None,
-        separate_mc: bool = False
+         # ── CHANGE 4: Remove `separate_mc` parameter from public API ─────────
+        # BEFORE: separate_mc: bool = False
+        # AFTER:  parameter removed — always separated.
+        # ── END CHANGE 4 ─────
     ) -> dict[str, list[str]]:
         """
         Fetch file URLs using either release years or specific record IDs.
@@ -142,7 +211,6 @@ class MetadataFetcher:
         Args:
             release_years: Optional list of release years
             record_ids: Optional list of specific record IDs
-            separate_mc: Whether to separate MC files from data files
             
         Returns:
             Dict mapping release/record keys to lists of file URLs
@@ -154,13 +222,13 @@ class MetadataFetcher:
         
         # Priority 2: Specified release years
         if release_years and len(release_years) > 0:
-            return self.fetch_by_release_years(release_years, separate_mc)
+            return self.fetch_by_release_years(release_years)
         
         # Priority 3: All available releases
         available = self.get_available_releases()
         all_releases = list(available.keys())
         logging.info(f"No specific releases specified, fetching all: {all_releases}")
-        return self.fetch_by_release_years(all_releases, separate_mc)
+        return self.fetch_by_release_years(all_releases)
     
     def _fetch_urls_for_releases(self, release_years: list[str]) -> dict[str, list[str]]:
         """
@@ -229,39 +297,61 @@ class MetadataFetcher:
         
         return file_list
     
+
     @staticmethod
-    def _separate_mc_files(release_files: dict[str, list[str]]) -> dict[str, list[str]]:
-        """
-        Separate MC files from data files.
-        
-        Creates separate entries with _mc suffix for MC files.
-        
-        Args:
-            release_files: Dict mapping release years to file URLs
-            
-        Returns:
-            Dict with MC files under "{year}_mc" keys and data under "{year}" keys
-        """
-        separated = {}
-        
+    def _separate_mc_files(
+        release_files: dict[str, list[str]]
+    ) -> dict[str, list[str]]:
+        # ── CHANGE 5: Replace loose substring match with strict classifier ────
+        # BEFORE (broken):
+        #     for url in file_urls:
+        #         if "mc" in url.lower():      # hits "opendata" in ALL URLs
+        #             mc_files.append(url)
+        #         else:
+        #             data_files.append(url)   # unclassifiable silently go here
+        #
+        # AFTER (strict):
+        separated: dict[str, list[str]] = {}
+        classification_errors: list[str] = []
+
         for year, file_urls in release_files.items():
-            mc_files = []
-            data_files = []
-            
+            data_files: list[str] = []
+            mc_files:   list[str] = []
+
             for url in file_urls:
-                if "mc" in url.lower():
+                try:
+                    url_type = _classify_url(url)
+                except ValueError as e:
+                    classification_errors.append(str(e))
+                    continue
+
+                if url_type == UrlType.MC:
                     mc_files.append(url)
                 else:
                     data_files.append(url)
-            
-            # Add data files (if any)
+
+            if classification_errors:
+                raise ValueError(
+                    f"Failed to classify {len(classification_errors)} URL(s):\n"
+                    + "\n".join(classification_errors[:10])
+                    + (f"\n... and {len(classification_errors) - 10} more"
+                       if len(classification_errors) > 10 else "")
+                )
+
             if data_files:
                 separated[year] = data_files
-            
-            # Add MC files with _mc suffix (if any)
             if mc_files:
                 separated[f"{year}_mc"] = mc_files
-        
+
+            logging.info(
+                f"Release '{year}': {len(data_files)} data files, "
+                f"{len(mc_files)} MC files"
+            )
+
+        # Post-separation integrity check — asserts zero cross-contamination
+        _assert_no_cross_contamination(separated)
+        # ── END CHANGE 5 ─────────────────────────────────────────────────────
+
         return separated
     
     def to_release_metadata(

--- a/services/pipelines/histograms_pipeline.py
+++ b/services/pipelines/histograms_pipeline.py
@@ -203,7 +203,9 @@ def _group_signatures_by_bumpnet(signatures: List[str]) -> Dict[str, List[str]]:
         elif cleaned.endswith("_outliers"):
             cleaned = cleaned[:-9]
 
-        match = re.search(r"_FS_(\d+e_\d+m_\d+j_\d+g)_IM_(\d+e_\d+m_\d+j_\d+g)$", cleaned)
+        #match = re.search(r"_FS_(\d+e_\d+m_\d+j_\d+g)_IM_(\d+e_\d+m_\d+j_\d+g)$", cleaned)
+        # NEW — matches index-based: IM_e0e1j0
+        match = re.search(r"_FS_(\d+e_\d+m_\d+j_\d+g)_IM_([e\dm\djg\d]*)$", cleaned)
         if not match:
             continue
         fs_str, im_str = match.groups()
@@ -287,7 +289,8 @@ def _group_im_files_by_signature(im_files: List[str]) -> Dict[str, List[str]]:
     groups = defaultdict(list)
     unmatched_files = []
     for filename in im_files:
-        match = re.search(r'_FS_(\d+e_\d+m_\d+j_\d+g)_IM_(\d+e_\d+m_\d+j_\d+g)', filename)
+        #match = re.search(r'_FS_(\d+e_\d+m_\d+j_\d+g)_IM_(\d+e_\d+m_\d+j_\d+g)', filename)
+        match = re.search(r'_FS_(\d+e_\d+m_\d+j_\d+g)_IM_([e0-9m j0-9g0-9]+)', filename)
         if match:
             fs_str, im_str = match.groups()
             bumpnet_name = _convert_to_bumpnet_name(fs_str, im_str)
@@ -300,23 +303,55 @@ def _group_im_files_by_signature(im_files: List[str]) -> Dict[str, List[str]]:
     return dict(groups)
 
 
-def _convert_to_bumpnet_name(fs_str: str, im_str: str) -> str:
-    particles = re.findall(r'(\d+)([emjg])', im_str)
-    combo_parts = [f"{p}{c}" for c, p in particles if c != '0']
-    combo = "".join(combo_parts) if combo_parts else "none"
+# def _convert_to_bumpnet_name(fs_str: str, im_str: str) -> str:
+#     particles = re.findall(r'(\d+)([emjg])', im_str)
+#     combo_parts = [f"{p}{c}" for c, p in particles if c != '0']
+#     combo = "".join(combo_parts) if combo_parts else "none"
 
+#     fs_particles = re.findall(r'(\d+)([emjg])', fs_str)
+#     fs_formatted = "_".join(f"{c}{p}x" for c, p in fs_particles)
+
+#     result = f"mass_{combo}_cat_{fs_formatted}"
+
+#     if 'cat' not in result and 'hCat' not in result:
+#         raise ValueError(
+#             f"Generated histogram name '{result}' doesn't contain 'cat' or 'hCat' "
+#             "- this will cause UnboundLocalError in BumpNet"
+#         )
+#     return result
+def _convert_to_bumpnet_name(fs_str: str, im_str: str) -> str:
+    """
+    Convert FS and IM strings to a BumpNet histogram name.
+
+    IM string is now index-based (e.g. "e0e1j0") so it passes through
+    directly as the combo part — no conversion needed.
+
+    FS string remains count-based (e.g. "2e_0m_3j_0g") and is formatted
+    as before (e.g. "2ex_0mx_3jx_0gx").
+
+    Examples:
+      fs="2e_0m_3j_0g"  im="e0j0"   → mass_e0j0_cat_2ex_0mx_3jx_0gx
+      fs="2e_0m_3j_0g"  im="e0e1j0" → mass_e0e1j0_cat_2ex_0mx_3jx_0gx
+      fs="2e_0m_3j_0g"  im="e1j0"   → mass_e1j0_cat_2ex_0mx_3jx_0gx  (future sub-leading)
+
+    The regex in _group_signatures_by_bumpnet that feeds this function
+    also needs to be updated.
+    """
+    # IM part is already index-based — use directly as combo
+    combo = im_str if im_str else "none"
+
+    # FS part: count-based "2e_0m_3j_0g" → "2ex_0mx_3jx_0gx"
     fs_particles = re.findall(r'(\d+)([emjg])', fs_str)
-    fs_formatted = "_".join(f"{c}{p}x" for c, p in fs_particles)
+    fs_formatted  = "_".join(f"{c}{p}x" for c, p in fs_particles)
 
     result = f"mass_{combo}_cat_{fs_formatted}"
 
     if 'cat' not in result and 'hCat' not in result:
         raise ValueError(
-            f"Generated histogram name '{result}' doesn't contain 'cat' or 'hCat' "
-            "- this will cause UnboundLocalError in BumpNet"
+            f"Generated histogram name '{result}' doesn't contain 'cat' — "
+            "BumpNet incompatible"
         )
     return result
-
 
 def _process_im_arrays_bumpnet(
     im_arrays_dir: str, output_dir: str, bin_widths_gev: list,

--- a/services/pipelines/histograms_pipeline.py
+++ b/services/pipelines/histograms_pipeline.py
@@ -205,7 +205,7 @@ def _group_signatures_by_bumpnet(signatures: List[str]) -> Dict[str, List[str]]:
 
         #match = re.search(r"_FS_(\d+e_\d+m_\d+j_\d+g)_IM_(\d+e_\d+m_\d+j_\d+g)$", cleaned)
         # NEW — matches index-based: IM_e0e1j0
-        match = re.search(r"_FS_(\d+e_\d+m_\d+j_\d+g)_IM_([e\dm\djg\d]*)$", cleaned)
+        match = re.search(r"_FS_(\d+e_\d+m_\d+j_\d+g)_IM_([emjg\d]+)$", cleaned)
         if not match:
             continue
         fs_str, im_str = match.groups()
@@ -290,7 +290,7 @@ def _group_im_files_by_signature(im_files: List[str]) -> Dict[str, List[str]]:
     unmatched_files = []
     for filename in im_files:
         #match = re.search(r'_FS_(\d+e_\d+m_\d+j_\d+g)_IM_(\d+e_\d+m_\d+j_\d+g)', filename)
-        match = re.search(r'_FS_(\d+e_\d+m_\d+j_\d+g)_IM_([e0-9m j0-9g0-9]+)', filename)
+        match = re.search(r'_FS_(\d+e_\d+m_\d+j_\d+g)_IM_([emjg\d]+)', filename)
         if match:
             fs_str, im_str = match.groups()
             bumpnet_name = _convert_to_bumpnet_name(fs_str, im_str)

--- a/services/pipelines/histograms_pipeline.py
+++ b/services/pipelines/histograms_pipeline.py
@@ -18,6 +18,57 @@ import math
 from services.storage.sqlite_shards import list_signatures, iter_arrays_for_signature
 
 
+def save_global_ranges(ranges: Dict, output_path: str):
+    import json
+    with open(output_path, "w") as f:
+        json.dump(ranges, f, indent=2)
+    logging.getLogger(__name__).info(f"Saved global ranges to {output_path}")
+
+def load_global_ranges(path: str) -> Dict[str, Tuple[float, float]]:
+    import json
+    with open(path) as f:
+        data = json.load(f)
+    return {k: tuple(v) for k, v in data.items()}
+
+def compute_global_ranges(
+    sqlite_files: List[str],
+    input_dir: str,
+    exclude_outliers: bool = True,
+) -> Dict[str, Tuple[float, float]]:
+    """
+    Scan ALL processed SQLite files and compute global min/max per bumpnet_name.
+    Returns dict: {bumpnet_name: (global_min, global_max)}
+    Save result to JSON before running histogram creation batches.
+    """
+    logger = logging.getLogger(__name__)
+    db_paths = [os.path.join(input_dir, f) for f in sqlite_files]
+
+    signatures = set()
+    for db_path in db_paths:
+        signatures.update(list_signatures(db_path))
+    signatures = sorted(signatures)
+
+    if exclude_outliers:
+        signatures = [s for s in signatures if not s.endswith("_outliers")]
+
+    grouped = _group_signatures_by_bumpnet(signatures)
+    logger.info(f"Computing global ranges for {len(grouped)} bumpnet signatures...")
+
+    ranges = {}
+    for bumpnet_name, group_sigs in grouped.items():
+        gmin, gmax = float("inf"), float("-inf")
+        for sig in group_sigs:
+            for db_path in db_paths:
+                for chunk in iter_arrays_for_signature(db_path, sig):
+                    if len(chunk) > 0:
+                        gmin = min(gmin, float(np.min(chunk)))
+                        gmax = max(gmax, float(np.max(chunk)))
+        if gmin < float("inf"):
+            ranges[bumpnet_name] = (gmin, gmax)
+
+    logger.info(f"Computed ranges for {len(ranges)} signatures")
+    return ranges
+
 def create_histograms(histograms_config: Dict, file_list: Optional[List[str]] = None):
     logger = _init_logging()
 
@@ -120,6 +171,10 @@ def _create_histograms_from_sqlite(
     output_dir = histograms_config["output_dir"]
     os.makedirs(output_dir, exist_ok=True)
 
+    # Load global ranges if available
+    global_ranges_path = histograms_config.get("global_ranges_path")
+    global_ranges = load_global_ranges(global_ranges_path) if global_ranges_path else None
+
     bin_width_gev = histograms_config["bin_width_gev"]
     bin_widths_gev = [bin_width_gev] if isinstance(bin_width_gev, (int, float)) else bin_width_gev
     use_bumpnet_naming = histograms_config.get("use_bumpnet_naming", False)
@@ -153,7 +208,8 @@ def _create_histograms_from_sqlite(
             hist_count = 0
             for bumpnet_name, group_sigs in grouped.items():
                 hists = _create_merged_histograms_from_sqlite_signatures(
-                    group_sigs, db_paths, bumpnet_name, bin_widths_gev, logger
+                    group_sigs, db_paths, bumpnet_name, bin_widths_gev, logger,
+                    global_ranges=global_ranges,
                 )
                 if hists:
                     _write_hists_to_shared_file(hists, root_filepath, logger)
@@ -162,7 +218,8 @@ def _create_histograms_from_sqlite(
         else:
             for bumpnet_name, group_sigs in grouped.items():
                 hists = _create_merged_histograms_from_sqlite_signatures(
-                    group_sigs, db_paths, bumpnet_name, bin_widths_gev, logger
+                    group_sigs, db_paths, bumpnet_name, bin_widths_gev, logger,
+                    global_ranges=global_ranges,
                 )
                 if hists:
                     root_filename = f"{bumpnet_name}_hists.root"
@@ -253,29 +310,46 @@ def _create_merged_histograms_from_sqlite_signatures(
     hist_name_base: str,
     bin_widths_gev: List[float],
     logger: logging.Logger,
+    global_ranges: Optional[Dict] = None,
 ) -> List[ROOT.TH1F]:
-    global_min, global_max = float("inf"), float("-inf")
-    has_data = False
 
-    for signature in signatures:
-        for chunk in _iter_signature_chunks(signature, db_paths):
-            has_data = True
-            global_min = min(global_min, float(np.min(chunk)))
-            global_max = max(global_max, float(np.max(chunk)))
+    if global_ranges is not None:
+        if hist_name_base not in global_ranges:
+            logger.warning(
+                f"{hist_name_base} not found in global_ranges — skipping. "
+                "Re-run scan-only job to regenerate global_ranges.json."
+            )
+            return []
+        global_min, global_max = global_ranges[hist_name_base]
+        logger.debug(f"{hist_name_base}: using global range [{global_min:.1f}, {global_max:.1f}]")
+    else:
+        # No global ranges provided — compute from available data
+        # WARNING: this will produce batch-local edges, hadd will fail
+        logger.warning(
+            f"{hist_name_base}: no global_ranges provided — "
+            "computing from batch data only. hadd merging will likely fail!"
+        )
+        global_min, global_max = float("inf"), float("-inf")
+        for signature in signatures:
+            for chunk in _iter_signature_chunks(signature, db_paths):
+                global_min = min(global_min, float(np.min(chunk)))
+                global_max = max(global_max, float(np.max(chunk)))
 
-    if not has_data:
-        logger.warning(f"No valid data found for {hist_name_base}")
+    if global_min == float("inf"):
         return []
+
+    if 'cat' not in hist_name_base and 'hCat' not in hist_name_base:
+        raise ValueError(
+            f"Invalid histogram name base '{hist_name_base}': must contain 'cat'"
+        )
 
     histograms = []
     for bin_width in bin_widths_gev:
         nbins = max(1, math.ceil((global_max - global_min) / bin_width))
         hist_name = f"ROI_{hist_name_base}_width_{bin_width}"
-        if "cat" not in hist_name_base and "hCat" not in hist_name_base:
-            raise ValueError(
-                f"Invalid histogram name base '{hist_name_base}': must contain 'cat' for BumpNet compatibility"
-            )
-        histograms.append(ROOT.TH1F(hist_name, hist_name, nbins, global_min, global_max))
+        histograms.append(
+            ROOT.TH1F(hist_name, hist_name, nbins, global_min, global_max)
+        )
 
     for signature in signatures:
         for chunk in _iter_signature_chunks(signature, db_paths):
@@ -283,7 +357,6 @@ def _create_merged_histograms_from_sqlite_signatures(
                 for val in chunk:
                     hist.Fill(float(val))
     return histograms
-
 
 def _group_im_files_by_signature(im_files: List[str]) -> Dict[str, List[str]]:
     groups = defaultdict(list)

--- a/services/pipelines/histograms_pipeline.py
+++ b/services/pipelines/histograms_pipeline.py
@@ -183,6 +183,20 @@ def _create_histograms_from_sqlite(
     output_filename = histograms_config.get("output_filename", "all_histograms.root")
 
     db_paths = [os.path.join(input_dir, f) for f in sqlite_files]
+
+    # Split SQLite files across histogram batch jobs
+    batch_job_index = histograms_config.get("batch_job_index")
+    total_batch_jobs = histograms_config.get("total_batch_jobs")
+    if batch_job_index is not None and total_batch_jobs is not None:
+        sqlite_files = _get_batch_files(
+            sorted(sqlite_files), batch_job_index, total_batch_jobs
+        )
+        db_paths = [os.path.join(input_dir, f) for f in sqlite_files]
+        logger.info(
+            f"Batch {batch_job_index}/{total_batch_jobs}: "
+            f"processing SQLite files: {sqlite_files}"
+        )
+    
     signatures = set()
     for db_path in db_paths:
         signatures.update(list_signatures(db_path))

--- a/services/pipelines/im_pipeline.py
+++ b/services/pipelines/im_pipeline.py
@@ -278,17 +278,58 @@ def _fs_dict_exceeding_threshold(fs_im_mapping: Dict, threshold: int) -> bool:
     return total_size >= threshold
 
 
+# def prepare_im_combination_name(
+#     filename: str,
+#     final_state: str,
+#     combination: Dict[str, int]
+# ) -> str:
+#     base_filename = filename.replace(".root", "")
+
+#     e_count = combination.get("Electrons", 0)
+#     j_count = combination.get("Jets", 0)
+#     m_count = combination.get("Muons", 0)
+#     g_count = combination.get("Photons", 0)
+
+#     combination_part = f"{e_count}e_{m_count}m_{j_count}j_{g_count}g"
+#     return f"{base_filename}_FS_{final_state}_IM_{combination_part}"
 def prepare_im_combination_name(
     filename: str,
     final_state: str,
     combination: Dict[str, int]
 ) -> str:
+    """
+    Build the SQLite signature name for a given IM combination.
+
+    IM part uses BumpNet index-based convention:
+      count N of particle type X → indices 0..N-1 → encoded as X0X1...X(N-1)
+
+    Examples:
+      {"Electrons": 1, "Jets": 1}          → IM_e0j0
+      {"Electrons": 2, "Jets": 1}          → IM_e0e1j0
+      {"Electrons": 1, "Muons": 1}         → IM_e0m0
+      {"Electrons": 2, "Muons": 1, "Jets": 1} → IM_e0e1m0j0
+
+    This is unambiguous: IM_e0j0 = leading e + leading j (2-body),
+    IM_e0e1j0 = leading e + sub-leading e + leading j (3-body).
+
+    Future sub-leading support (Fix 2): when start_indices are added,
+    {"Electrons": 1, start=1, "Jets": 1, start=0} → IM_e1j0 naturally.
+    """
     base_filename = filename.replace(".root", "")
 
-    e_count = combination.get("Electrons", 0)
-    j_count = combination.get("Jets", 0)
-    m_count = combination.get("Muons", 0)
-    g_count = combination.get("Photons", 0)
+    # Canonical particle order matches BumpNet convention
+    PARTICLE_ORDER = [
+        ("Electrons", "e"),
+        ("Muons",     "m"),
+        ("Jets",      "j"),
+        ("Photons",   "g"),
+    ]
 
-    combination_part = f"{e_count}e_{m_count}m_{j_count}j_{g_count}g"
-    return f"{base_filename}_FS_{final_state}_IM_{combination_part}"
+    im_parts = []
+    for ptype, letter in PARTICLE_ORDER:
+        count = combination.get(ptype, 0)
+        for idx in range(count):
+            im_parts.append(f"{letter}{idx}")
+
+    im_str = "".join(im_parts)   # e.g. "e0e1j0"
+    return f"{base_filename}_FS_{final_state}_IM_{im_str}"

--- a/services/pipelines/im_pipeline.py
+++ b/services/pipelines/im_pipeline.py
@@ -13,13 +13,14 @@ import awkward as ak
 import numpy as np
 
 from services.calculations.im_calculator import IMCalculator
+from services.calculations.combinatorics import get_count, get_start
 
 
 def process_final_state(
     final_state: str,
     fs_events: ak.Array,
     filename: str,
-    all_combinations: List[Dict[str, int]],
+    all_combinations: List[Dict],
     config: Dict,
     output_dir: str,
     logger: logging.Logger,
@@ -135,7 +136,7 @@ def _convert_array_to_gev(inv_mass: ak.Array) -> ak.Array:
 
 def _calculate_combination_invariant_mass(
     fs_events: ak.Array,
-    combination: Dict[str, int],
+    combination: Dict,
     config: Dict,
     calculator: IMCalculator,
     logger: logging.Logger,
@@ -278,42 +279,30 @@ def _fs_dict_exceeding_threshold(fs_im_mapping: Dict, threshold: int) -> bool:
     return total_size >= threshold
 
 
-# def prepare_im_combination_name(
-#     filename: str,
-#     final_state: str,
-#     combination: Dict[str, int]
-# ) -> str:
-#     base_filename = filename.replace(".root", "")
-
-#     e_count = combination.get("Electrons", 0)
-#     j_count = combination.get("Jets", 0)
-#     m_count = combination.get("Muons", 0)
-#     g_count = combination.get("Photons", 0)
-
-#     combination_part = f"{e_count}e_{m_count}m_{j_count}j_{g_count}g"
-#     return f"{base_filename}_FS_{final_state}_IM_{combination_part}"
 def prepare_im_combination_name(
     filename: str,
     final_state: str,
-    combination: Dict[str, int]
+    combination: Dict,
 ) -> str:
     """
     Build the SQLite signature name for a given IM combination.
 
-    IM part uses BumpNet index-based convention:
-      count N of particle type X → indices 0..N-1 → encoded as X0X1...X(N-1)
+    IM part encodes each selected particle as letter + rank index.
+    Works with both plain-int values (start=0) and (count, start_index) tuples.
 
-    Examples:
-      {"Electrons": 1, "Jets": 1}          → IM_e0j0
-      {"Electrons": 2, "Jets": 1}          → IM_e0e1j0
-      {"Electrons": 1, "Muons": 1}         → IM_e0m0
-      {"Electrons": 2, "Muons": 1, "Jets": 1} → IM_e0e1m0j0
+    Examples (leading only, start=0):
+        {"Electrons": (1, 0), "Jets": (1, 0)}       → IM_e0j0
+        {"Electrons": (2, 0), "Jets": (1, 0)}       → IM_e0e1j0
+        {"Electrons": (1, 0), "Muons": (1, 0)}      → IM_e0m0
 
-    This is unambiguous: IM_e0j0 = leading e + leading j (2-body),
-    IM_e0e1j0 = leading e + sub-leading e + leading j (3-body).
+    Examples (sub-leading, start>0):
+        {"Electrons": (1, 1), "Jets": (1, 0)}       → IM_e1j0
+        {"Electrons": (1, 0), "Jets": (1, 1)}       → IM_e0j1
+        {"Electrons": (1, 1), "Jets": (1, 1)}       → IM_e1j1
+        {"Electrons": (2, 1), "Jets": (1, 0)}       → IM_e1e2j0
 
-    Future sub-leading support (Fix 2): when start_indices are added,
-    {"Electrons": 1, start=1, "Jets": 1, start=0} → IM_e1j0 naturally.
+    The name is unambiguous: IM_e1j0 always means sub-leading electron
+    + leading jet (2-body invariant mass).
     """
     base_filename = filename.replace(".root", "")
 
@@ -327,9 +316,13 @@ def prepare_im_combination_name(
 
     im_parts = []
     for ptype, letter in PARTICLE_ORDER:
-        count = combination.get(ptype, 0)
-        for idx in range(count):
+        if ptype not in combination:
+            continue
+        value = combination[ptype]
+        count = get_count(value)
+        start = get_start(value)
+        for idx in range(start, start + count):
             im_parts.append(f"{letter}{idx}")
 
-    im_str = "".join(im_parts)   # e.g. "e0e1j0"
+    im_str = "".join(im_parts)   # e.g. "e0j0", "e1j0", "e0e1j0"
     return f"{base_filename}_FS_{final_state}_IM_{im_str}"

--- a/services/pipelines/post_processing_pipeline.py
+++ b/services/pipelines/post_processing_pipeline.py
@@ -183,7 +183,7 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
             processed += 1                          # ← new
             if processed % COMMIT_EVERY == 0:       # ← new
                 writer.commit()                     # ← new: periodic commit
-                logger.info(f"Post-processing progress: {processed}/{len(signatures)} signatures committed")  # ← new
+                logger.info(f"Post-processing progress: {processed}/{len(fs_im_key)} signatures committed")  # ← new
 
         writer.commit()  # ← final commit for remainder    
     finally:
@@ -268,9 +268,7 @@ def _find_rightmost_highest_peak(
     if peak_bin_idx is None:
         return None
 
-    # peak_mass = bin_edges[peak_bin_idx]
-    # NEW — returns right edge of peak bin:
-    peak_mass = bin_edges[peak_bin_idx + 1]
+    peak_mass = bin_edges[peak_bin_idx]
     logger.debug(f"Found peak at bin {peak_bin_idx} with count {max_count}, mass = {peak_mass:.2f} GeV")
     return peak_mass
 

--- a/services/pipelines/post_processing_pipeline.py
+++ b/services/pipelines/post_processing_pipeline.py
@@ -128,14 +128,38 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
         f"Processing {len(signatures)} signatures from {len(sqlite_files)} IM shard file(s) "
         f"into {shard_name}"
     )
+# NEW — group by FS_IM key first, then merge all chunks:
+    # group signatures by FS_IM key (strip batch/chunk prefix)
+    from collections import defaultdict
+    fs_im_groups = defaultdict(list)
+    for sig in signatures:
+        # extract FS_IM part: everything from "_FS_" onward
+        m = re.search(r'(_FS_.+)', sig)
+        fs_im_key = m.group(1) if m else sig
+        fs_im_groups[fs_im_key].append(sig)
+
+    logger.info(f"Grouped {len(signatures)} signatures into {len(fs_im_groups)} unique FS_IM keys")
 
     written = 0
+    COMMIT_EVERY = 1000
+    processed = 0
     try:
-        for signature in sorted(signatures):
+        for fs_im_key in sorted(fs_im_groups.keys()):
+            chunk_sigs = fs_im_groups[fs_im_key]
             chunks = []
-            for filename in sqlite_files:
-                db_path = os.path.join(input_dir, filename)
-                chunks.extend(iter_arrays_for_signature(db_path, signature))
+            for sig in chunk_sigs:
+                for filename in sqlite_files:
+                    db_path = os.path.join(input_dir, filename)
+                    chunks.extend(iter_arrays_for_signature(db_path, sig))
+    # written = 0
+    # COMMIT_EVERY = 1000  # commit every 1000 signatures to keep WAL small
+    # processed = 0
+    # try:
+    #     for signature in sorted(signatures):
+    #         chunks = []
+    #         for filename in sqlite_files:
+    #             db_path = os.path.join(input_dir, filename)
+    #             chunks.extend(iter_arrays_for_signature(db_path, signature))
             if not chunks:
                 continue
 
@@ -150,12 +174,18 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
 
             main_array, outliers_array = _split_by_first_empty_bin(filtered, bin_width, logger)
             if len(main_array) > 0:
-                writer.append_array(f"{signature}_main", main_array)
+                writer.append_array(f"{fs_im_key}_main", main_array)
                 written += 1
             if len(outliers_array) > 0:
-                writer.append_array(f"{signature}_outliers", outliers_array)
+                writer.append_array(f"{fs_im_key}_outliers", outliers_array)
                 written += 1
-        writer.commit()
+
+            processed += 1                          # ← new
+            if processed % COMMIT_EVERY == 0:       # ← new
+                writer.commit()                     # ← new: periodic commit
+                logger.info(f"Post-processing progress: {processed}/{len(signatures)} signatures committed")  # ← new
+
+        writer.commit()  # ← final commit for remainder    
     finally:
         writer.close()
 
@@ -238,7 +268,9 @@ def _find_rightmost_highest_peak(
     if peak_bin_idx is None:
         return None
 
-    peak_mass = bin_edges[peak_bin_idx]
+    # peak_mass = bin_edges[peak_bin_idx]
+    # NEW — returns right edge of peak bin:
+    peak_mass = bin_edges[peak_bin_idx + 1]
     logger.debug(f"Found peak at bin {peak_bin_idx} with count {max_count}, mass = {peak_mass:.2f} GeV")
     return peak_mass
 

--- a/submit.sh
+++ b/submit.sh
@@ -69,7 +69,7 @@ cd ${PIPELINE_DIR}
 
 export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
-lsetup "views LCG_106a_ATLAS_1 x86_64-el9-gcc14-opt"
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
 
 python -u main.py --config "${CONFIG}" --run-dir "${RUN_DIR}" \
     > "${LOG_DIR}/pipeline.out" \
@@ -95,7 +95,7 @@ cd ${PIPELINE_DIR}
 
 export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
-lsetup "views LCG_106a_ATLAS_1 x86_64-el9-gcc14-opt"
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
 
 python -u main.py --config "${CONFIG}" \
     --batch-job-index \${PBS_ARRAY_INDEX} \
@@ -122,7 +122,7 @@ cd ${PIPELINE_DIR}
 
 export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
-lsetup "views LCG_106a_ATLAS_1 x86_64-el9-gcc14-opt"
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
 
 python -u main.py --config "${CONFIG}" \
     --merge-only \

--- a/submit_data.sh
+++ b/submit_data.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # ===========================================================================
 # Submit DATA pipeline (parse_mc: false)
+#
+# Job chain:
+#   batch array (parsing+mass_calculating) → postproc (single job) →
+#   scan → histogram array → merge
 # ===========================================================================
 
 set -e
@@ -10,9 +14,10 @@ CONFIG="configWmaxTotal_up4j_minEvt10_subleading.yaml"
 CPUS_PER_JOB=4
 MEM_PER_JOB="180gb"
 WALLTIME="12:00:00"
+POSTPROC_WALLTIME="24:00:00"
 SCAN_WALLTIME="04:00:00"
 HIST_WALLTIME="24:00:00"
-MERGE_WALLTIME="04:00:00"
+MERGE_WALLTIME="08:00:00"
 QUEUE="N"
 
 PIPELINE_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -37,7 +42,7 @@ echo "ATLAS Pipeline — DATA submission"
 echo "Run dir: ${RUN_DIR}"
 echo "=============================================="
 
-# Stage 1: submit N individual batch jobs (parsing+mass_calc+post_processing)
+# Stage 1: parsing + mass_calculating only (per batch)
 BATCH_JOB_IDS=""
 for i in $(seq 1 $NUM_JOBS); do
     JOB_ID=$(qsub <<EOF
@@ -58,7 +63,7 @@ lsetup "views LCG_107 x86_64-el9-gcc14-opt"
 source ${PIPELINE_DIR}/atlasenv/bin/activate
 
 python -u main.py --config "${CONFIG}" \
-    --tasks parsing,mass_calculating,post_processing \
+    --tasks parsing,mass_calculating \
     --parse-mc false \
     --batch-job-index ${i} \
     --total-batch-jobs ${NUM_JOBS} \
@@ -68,17 +73,39 @@ python -u main.py --config "${CONFIG}" \
 EOF
     )
     echo "Submitted batch ${i}: ${JOB_ID}"
-    if [ -z "$BATCH_JOB_IDS" ]; then
-        BATCH_JOB_IDS="${JOB_ID}"
-    else
-        BATCH_JOB_IDS="${BATCH_JOB_IDS}:${JOB_ID}"
-    fi
+    BATCH_JOB_IDS="${BATCH_JOB_IDS:+${BATCH_JOB_IDS}:}${JOB_ID}"
 done
-
 echo "All batch jobs: ${BATCH_JOB_IDS}"
 
-# Stage 2: scan — depends on ALL batch jobs
-SCAN_JOB_ID=$(qsub -W depend=afterok:"${BATCH_JOB_IDS}" <<EOF
+# Stage 2: post-processing — single job reading ALL im_batch_*.sqlite files
+POSTPROC_JOB_ID=$(qsub -W depend=afterok:"${BATCH_JOB_IDS}" <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_data_postproc
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=4:mem=64gb
+#PBS -l io=5
+#PBS -l walltime=${POSTPROC_WALLTIME}
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py --config "${CONFIG}" \
+    --tasks post_processing \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/postproc.out" \
+    2> "${LOG_DIR}/postproc.err"
+EOF
+)
+echo "Submitted postproc: ${POSTPROC_JOB_ID} (depends on all batches)"
+
+# Stage 3: scan global ranges — depends on postproc
+SCAN_JOB_ID=$(qsub -W depend=afterok:"${POSTPROC_JOB_ID}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
 #PBS -N atlas_data_scan
@@ -102,9 +129,9 @@ python -u main.py --config "${CONFIG}" \
     2> "${LOG_DIR}/scan.err"
 EOF
 )
-echo "Submitted scan: ${SCAN_JOB_ID} (depends on all batches)"
+echo "Submitted scan: ${SCAN_JOB_ID} (depends on postproc)"
 
-# Stage 3: histogram jobs — each depends on scan
+# Stage 4: histogram creation — per batch, depends on scan
 HIST_JOB_IDS=""
 for i in $(seq 1 $NUM_JOBS); do
     JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
@@ -134,16 +161,11 @@ python -u main.py --config "${CONFIG}" \
 EOF
     )
     echo "Submitted hist ${i}: ${JOB_ID}"
-    if [ -z "$HIST_JOB_IDS" ]; then
-        HIST_JOB_IDS="${JOB_ID}"
-    else
-        HIST_JOB_IDS="${HIST_JOB_IDS}:${JOB_ID}"
-    fi
+    HIST_JOB_IDS="${HIST_JOB_IDS:+${HIST_JOB_IDS}:}${JOB_ID}"
 done
-
 echo "All hist jobs: ${HIST_JOB_IDS}"
 
-# Stage 4: merge — depends on ALL histogram jobs
+# Stage 5: merge — depends on ALL histogram jobs
 MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_IDS}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
@@ -173,6 +195,7 @@ echo "Submitted merge: ${MERGE_JOB_ID} (depends on all hist jobs)"
 echo ""
 echo "Job chain:"
 echo "  Batches:    ${BATCH_JOB_IDS}"
+echo "  Postproc:   ${POSTPROC_JOB_ID}"
 echo "  Scan:       ${SCAN_JOB_ID}"
 echo "  Histograms: ${HIST_JOB_IDS}"
 echo "  Merge:      ${MERGE_JOB_ID}"
@@ -180,4 +203,3 @@ echo ""
 echo "Monitor:  qstat -u \$USER"
 echo "Logs:     ${LOG_DIR}/"
 echo "Output:   ${RUN_DIR}/"
-echo ""

--- a/submit_data.sh
+++ b/submit_data.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# ===========================================================================
+# Submit DATA pipeline (parse_mc: false)
+# Run this first, then submit_mc.sh
+# ===========================================================================
+
+set -e
+
+NUM_JOBS=2
+CONFIG="configWmaxTotal_up4j_minEvt100_subleading.yaml"
+CPUS_PER_JOB=4
+MEM_PER_JOB="180gb"
+WALLTIME="2:00:00"
+SCAN_WALLTIME="04:00:00"
+HIST_WALLTIME="24:00:00"
+MERGE_WALLTIME="04:00:00"
+QUEUE="N"
+
+PIPELINE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+read RUN_NAME BASE_DIR <<< $(python3 -c "
+import yaml
+with open('${CONFIG}') as f:
+    c = yaml.safe_load(f)
+m = c.get('run_metadata', {})
+print(m.get('run_name', 'pipeline_run'), m.get('base_output_dir', './output'))")
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RUN_DIR="${BASE_DIR}/${RUN_NAME}_data_${TIMESTAMP}"
+LOG_DIR="${RUN_DIR}/logs"
+mkdir -p "${LOG_DIR}"
+
+cp "${PIPELINE_DIR}/${CONFIG}" "${LOG_DIR}/"
+cp "${PIPELINE_DIR}/submit_data.sh" "${LOG_DIR}/"
+
+echo "=============================================="
+echo "ATLAS Pipeline — DATA submission"
+echo "Run dir: ${RUN_DIR}"
+echo "=============================================="
+
+# Stage 1: parsing + mass_calc + post_processing (data only, no histograms)
+ARRAY_JOB_ID=$(qsub <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_data_batch
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
+#PBS -l io=5
+#PBS -l walltime=${WALLTIME}
+#PBS -J 1-${NUM_JOBS}
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+# Override parse_mc to false for data
+python -u main.py --config "${CONFIG}" \
+    --tasks parsing,mass_calculating,post_processing \
+    --parse-mc false \
+    --batch-job-index \${PBS_ARRAY_INDEX} \
+    --total-batch-jobs ${NUM_JOBS} \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/batch_\${PBS_ARRAY_INDEX}.out" \
+    2> "${LOG_DIR}/batch_\${PBS_ARRAY_INDEX}.err"
+EOF
+)
+echo "Submitted data batch array: ${ARRAY_JOB_ID}"
+
+# Stage 2: scan global ranges
+SCAN_JOB_ID=$(qsub -W depend=afterok:"${ARRAY_JOB_ID}" <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_data_scan
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=2:mem=32gb
+#PBS -l io=5
+#PBS -l walltime=${SCAN_WALLTIME}
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py --config "${CONFIG}" \
+    --scan-only \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/scan.out" \
+    2> "${LOG_DIR}/scan.err"
+EOF
+)
+echo "Submitted data scan: ${SCAN_JOB_ID} (depends on ${ARRAY_JOB_ID})"
+
+# Stage 3: histogram creation array
+HIST_JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_data_hist
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
+#PBS -l io=5
+#PBS -l walltime=${HIST_WALLTIME}
+#PBS -J 1-${NUM_JOBS}
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py --config "${CONFIG}" \
+    --tasks histogram_creation \
+    --batch-job-index \${PBS_ARRAY_INDEX} \
+    --total-batch-jobs ${NUM_JOBS} \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/hist_\${PBS_ARRAY_INDEX}.out" \
+    2> "${LOG_DIR}/hist_\${PBS_ARRAY_INDEX}.err"
+EOF
+)
+echo "Submitted data histograms: ${HIST_JOB_ID} (depends on ${SCAN_JOB_ID})"
+
+# Stage 4: merge
+MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_ID}" <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_data_merge
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=2:mem=32gb
+#PBS -l io=5
+#PBS -l walltime=${MERGE_WALLTIME}
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py --config "${CONFIG}" \
+    --merge-only \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/merge.out" \
+    2> "${LOG_DIR}/merge.err"
+EOF
+)
+echo "Submitted data merge: ${MERGE_JOB_ID} (depends on ${HIST_JOB_ID})"
+
+echo ""
+echo "Job chain:"
+echo "  Batch:      ${ARRAY_JOB_ID}"
+echo "  Scan:       ${SCAN_JOB_ID}"
+echo "  Histograms: ${HIST_JOB_ID}"
+echo "  Merge:      ${MERGE_JOB_ID}"
+echo ""
+echo "Data run dir: ${RUN_DIR}"
+echo "When complete, run: bash submit_mc.sh"

--- a/submit_data.sh
+++ b/submit_data.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 # ===========================================================================
 # Submit DATA pipeline (parse_mc: false)
-# Run this first, then submit_mc.sh
 # ===========================================================================
 
 set -e
 
-NUM_JOBS=2
-CONFIG="configWmaxTotal_up4j_minEvt100_subleading.yaml"
+NUM_JOBS=3
+CONFIG="configWmaxTotal_up4j_minEvt10_subleading.yaml"
 CPUS_PER_JOB=4
 MEM_PER_JOB="180gb"
-WALLTIME="2:00:00"
+WALLTIME="12:00:00"
 SCAN_WALLTIME="04:00:00"
 HIST_WALLTIME="24:00:00"
 MERGE_WALLTIME="04:00:00"
@@ -38,17 +37,18 @@ echo "ATLAS Pipeline — DATA submission"
 echo "Run dir: ${RUN_DIR}"
 echo "=============================================="
 
-# Stage 1: parsing + mass_calc + post_processing (data only, no histograms)
-ARRAY_JOB_ID=$(qsub <<EOF
+# Stage 1: submit N individual batch jobs (parsing+mass_calc+post_processing)
+BATCH_JOB_IDS=""
+for i in $(seq 1 $NUM_JOBS); do
+    JOB_ID=$(qsub <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
-#PBS -N atlas_data_batch
+#PBS -N atlas_data_batch_${i}
 #PBS -o ${LOG_DIR}/
 #PBS -e ${LOG_DIR}/
 #PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
 #PBS -l io=5
 #PBS -l walltime=${WALLTIME}
-#PBS -J 1-${NUM_JOBS}
 
 cd ${PIPELINE_DIR}
 
@@ -57,27 +57,34 @@ source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
 lsetup "views LCG_107 x86_64-el9-gcc14-opt"
 source ${PIPELINE_DIR}/atlasenv/bin/activate
 
-# Override parse_mc to false for data
 python -u main.py --config "${CONFIG}" \
     --tasks parsing,mass_calculating,post_processing \
     --parse-mc false \
-    --batch-job-index \${PBS_ARRAY_INDEX} \
+    --batch-job-index ${i} \
     --total-batch-jobs ${NUM_JOBS} \
     --run-dir "${RUN_DIR}" \
-    > "${LOG_DIR}/batch_\${PBS_ARRAY_INDEX}.out" \
-    2> "${LOG_DIR}/batch_\${PBS_ARRAY_INDEX}.err"
+    > "${LOG_DIR}/batch_${i}.out" \
+    2> "${LOG_DIR}/batch_${i}.err"
 EOF
-)
-echo "Submitted data batch array: ${ARRAY_JOB_ID}"
+    )
+    echo "Submitted batch ${i}: ${JOB_ID}"
+    if [ -z "$BATCH_JOB_IDS" ]; then
+        BATCH_JOB_IDS="${JOB_ID}"
+    else
+        BATCH_JOB_IDS="${BATCH_JOB_IDS}:${JOB_ID}"
+    fi
+done
 
-# Stage 2: scan global ranges
-SCAN_JOB_ID=$(qsub -W depend=afterok:"${ARRAY_JOB_ID}" <<EOF
+echo "All batch jobs: ${BATCH_JOB_IDS}"
+
+# Stage 2: scan — depends on ALL batch jobs
+SCAN_JOB_ID=$(qsub -W depend=afterok:"${BATCH_JOB_IDS}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
 #PBS -N atlas_data_scan
 #PBS -o ${LOG_DIR}/
 #PBS -e ${LOG_DIR}/
-#PBS -l select=1:ncpus=2:mem=32gb
+#PBS -l select=1:ncpus=2:mem=64gb
 #PBS -l io=5
 #PBS -l walltime=${SCAN_WALLTIME}
 
@@ -95,19 +102,20 @@ python -u main.py --config "${CONFIG}" \
     2> "${LOG_DIR}/scan.err"
 EOF
 )
-echo "Submitted data scan: ${SCAN_JOB_ID} (depends on ${ARRAY_JOB_ID})"
+echo "Submitted scan: ${SCAN_JOB_ID} (depends on all batches)"
 
-# Stage 3: histogram creation array
-HIST_JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
+# Stage 3: histogram jobs — each depends on scan
+HIST_JOB_IDS=""
+for i in $(seq 1 $NUM_JOBS); do
+    JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
-#PBS -N atlas_data_hist
+#PBS -N atlas_data_hist_${i}
 #PBS -o ${LOG_DIR}/
 #PBS -e ${LOG_DIR}/
 #PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
 #PBS -l io=5
 #PBS -l walltime=${HIST_WALLTIME}
-#PBS -J 1-${NUM_JOBS}
 
 cd ${PIPELINE_DIR}
 
@@ -118,17 +126,25 @@ source ${PIPELINE_DIR}/atlasenv/bin/activate
 
 python -u main.py --config "${CONFIG}" \
     --tasks histogram_creation \
-    --batch-job-index \${PBS_ARRAY_INDEX} \
+    --batch-job-index ${i} \
     --total-batch-jobs ${NUM_JOBS} \
     --run-dir "${RUN_DIR}" \
-    > "${LOG_DIR}/hist_\${PBS_ARRAY_INDEX}.out" \
-    2> "${LOG_DIR}/hist_\${PBS_ARRAY_INDEX}.err"
+    > "${LOG_DIR}/hist_${i}.out" \
+    2> "${LOG_DIR}/hist_${i}.err"
 EOF
-)
-echo "Submitted data histograms: ${HIST_JOB_ID} (depends on ${SCAN_JOB_ID})"
+    )
+    echo "Submitted hist ${i}: ${JOB_ID}"
+    if [ -z "$HIST_JOB_IDS" ]; then
+        HIST_JOB_IDS="${JOB_ID}"
+    else
+        HIST_JOB_IDS="${HIST_JOB_IDS}:${JOB_ID}"
+    fi
+done
 
-# Stage 4: merge
-MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_ID}" <<EOF
+echo "All hist jobs: ${HIST_JOB_IDS}"
+
+# Stage 4: merge — depends on ALL histogram jobs
+MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_IDS}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
 #PBS -N atlas_data_merge
@@ -152,14 +168,16 @@ python -u main.py --config "${CONFIG}" \
     2> "${LOG_DIR}/merge.err"
 EOF
 )
-echo "Submitted data merge: ${MERGE_JOB_ID} (depends on ${HIST_JOB_ID})"
+echo "Submitted merge: ${MERGE_JOB_ID} (depends on all hist jobs)"
 
 echo ""
 echo "Job chain:"
-echo "  Batch:      ${ARRAY_JOB_ID}"
+echo "  Batches:    ${BATCH_JOB_IDS}"
 echo "  Scan:       ${SCAN_JOB_ID}"
-echo "  Histograms: ${HIST_JOB_ID}"
+echo "  Histograms: ${HIST_JOB_IDS}"
 echo "  Merge:      ${MERGE_JOB_ID}"
 echo ""
-echo "Data run dir: ${RUN_DIR}"
-echo "When complete, run: bash submit_mc.sh"
+echo "Monitor:  qstat -u \$USER"
+echo "Logs:     ${LOG_DIR}/"
+echo "Output:   ${RUN_DIR}/"
+echo ""

--- a/submit_mass_calc.sh
+++ b/submit_mass_calc.sh
@@ -14,7 +14,7 @@
 set -e
 
 # --- Configuration ---------------------------------------------------------
-CONFIG="config10GeVbin.yaml"
+CONFIG="config10GeVbin_25MeV.yaml"
 CPUS_PER_JOB=1                    # single CPU per job — no parallel processes
 MEM_PER_JOB="16gb"                # one file at a time needs much less memory
 WALLTIME="04:00:00"               # one parsed chunk takes ~10-20 min
@@ -23,7 +23,8 @@ SUBMIT_DELAY=2                    # seconds between submissions (be polite)
 MAX_JOBS=200                      # safety cap — won't submit more than this
 
 # The existing run directory with parsed_data/ inside
-RUN_DIR="/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_full_fixComb_fixCut_20260403_230628"
+# RUN_DIR="/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_full_fixComb_fixCut_20260403_230628"
+RUN_DIR="/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_full_fixComb_20260414_155708"
 PARSED_DIR="${RUN_DIR}/parsed_data"
 
 PIPELINE_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/submit_mass_calc.sh
+++ b/submit_mass_calc.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# ===========================================================================
+# submit_mass_calc.sh
+#
+# Runs mass calculation on already-parsed data, one chunk per PBS job.
+# Each job processes exactly ONE parsed ROOT file, keeping memory low.
+#
+# Parsing must already be done. Set PARSED_DIR and RUN_DIR below.
+#
+# Usage:
+#   bash submit_mass_calc.sh
+# ===========================================================================
+
+set -e
+
+# --- Configuration ---------------------------------------------------------
+CONFIG="config10GeVbin.yaml"
+CPUS_PER_JOB=1                    # single CPU per job — no parallel processes
+MEM_PER_JOB="16gb"                # one file at a time needs much less memory
+WALLTIME="04:00:00"               # one parsed chunk takes ~10-20 min
+QUEUE="N"
+SUBMIT_DELAY=2                    # seconds between submissions (be polite)
+MAX_JOBS=200                      # safety cap — won't submit more than this
+
+# The existing run directory with parsed_data/ inside
+RUN_DIR="/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data/atlas_full_fixComb_fixCut_20260403_230628"
+PARSED_DIR="${RUN_DIR}/parsed_data"
+
+PIPELINE_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="${RUN_DIR}/logs/mass_calc"
+mkdir -p "${LOG_DIR}"
+
+# --- Find parsed ROOT files -------------------------------------------------
+mapfile -t ROOT_FILES < <(find "${PARSED_DIR}" -name "*.root" | sort)
+TOTAL=${#ROOT_FILES[@]}
+
+if [ "$TOTAL" -eq 0 ]; then
+    echo "ERROR: No ROOT files found in ${PARSED_DIR}"
+    exit 1
+fi
+
+if [ "$TOTAL" -gt "$MAX_JOBS" ]; then
+    echo "WARNING: Found ${TOTAL} files but MAX_JOBS=${MAX_JOBS}. Capping."
+    TOTAL=$MAX_JOBS
+fi
+
+echo "=============================================="
+echo "Mass Calculation — one job per parsed chunk"
+echo "=============================================="
+echo "Config     : ${CONFIG}"
+echo "Run dir    : ${RUN_DIR}"
+echo "Parsed dir : ${PARSED_DIR}"
+echo "Chunks     : ${TOTAL}"
+echo "CPUs/job   : ${CPUS_PER_JOB}"
+echo "Mem/job    : ${MEM_PER_JOB}"
+echo "Walltime   : ${WALLTIME}"
+echo "=============================================="
+echo ""
+echo "Submitting ${TOTAL} jobs..."
+echo ""
+
+JOB_IDS=()
+
+for ((i=0; i<TOTAL; i++)); do
+    ROOT_FILE="${ROOT_FILES[$i]}"
+    CHUNK_NAME=$(basename "${ROOT_FILE}" .root)
+    JOB_NUM=$((i + 1))
+
+    JOB_ID=$(qsub <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N mc_${JOB_NUM}
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
+#PBS -l io=31
+#PBS -l walltime=${WALLTIME}
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+# Override input_dir to point at the single file's parent dir,
+# and use batch index to select exactly this one file
+python -u main.py \
+    --config "${CONFIG}" \
+    --run-dir "${RUN_DIR}" \
+    --tasks mass_calculating \
+    --batch-job-index ${JOB_NUM} \
+    --total-batch-jobs ${TOTAL} \
+    > "${LOG_DIR}/${CHUNK_NAME}.out" \
+    2> "${LOG_DIR}/${CHUNK_NAME}.err"
+EOF
+    )
+
+    JOB_IDS+=("${JOB_ID}")
+    echo "  [${JOB_NUM}/${TOTAL}] ${CHUNK_NAME} → ${JOB_ID}"
+    sleep ${SUBMIT_DELAY}
+done
+
+echo ""
+echo "Submitted ${#JOB_IDS[@]} jobs."
+echo ""
+
+# --- Submit post-processing + histogram job after all mass calc jobs finish -
+# Build depend string: afterok:id1:id2:...
+DEPEND_STR=$(IFS=:; echo "${JOB_IDS[*]}")
+
+echo "Submitting post-processing + histogram job (depends on all above)..."
+
+MERGE_JOB_ID=$(qsub -W depend=afterok:"${DEPEND_STR}" <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_postproc
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=2:mem=32gb
+#PBS -l io=5
+#PBS -l walltime=12:00:00
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py \
+    --config "${CONFIG}" \
+    --run-dir "${RUN_DIR}" \
+    --tasks post_processing,histogram_creation \
+    > "${LOG_DIR}/postproc.out" \
+    2> "${LOG_DIR}/postproc.err"
+EOF
+)
+
+echo "Post-processing job: ${MERGE_JOB_ID}"
+echo ""
+echo "Monitor : qstat -u \$USER"
+echo "Logs    : ${LOG_DIR}/"
+echo ""
+echo "Each job uses ~1 CPU and ~16GB — one parsed chunk at a time."
+echo "Memory should stay well under limit on each node."

--- a/submit_mc.sh
+++ b/submit_mc.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 # ===========================================================================
 # Submit MC pipeline (parse_mc: true)
-# Run after submit_data.sh completes (or independently)
 # ===========================================================================
 
 set -e
 
-NUM_JOBS=12
-CONFIG="configWmaxTotal_up4j_minEvt100_subleading.yaml"
+NUM_JOBS=3
+CONFIG="configWmaxTotal_up4j_minEvt10_subleading.yaml"
 CPUS_PER_JOB=4
 MEM_PER_JOB="180gb"
-WALLTIME="72:00:00"
+WALLTIME="12:00:00"
 SCAN_WALLTIME="04:00:00"
 HIST_WALLTIME="24:00:00"
 MERGE_WALLTIME="04:00:00"
@@ -38,17 +37,18 @@ echo "ATLAS Pipeline — MC submission"
 echo "Run dir: ${RUN_DIR}"
 echo "=============================================="
 
-# Stage 1: parsing + mass_calc + post_processing (MC only)
-ARRAY_JOB_ID=$(qsub <<EOF
+# Stage 1: submit N individual batch jobs (parsing+mass_calc+post_processing)
+BATCH_JOB_IDS=""
+for i in $(seq 1 $NUM_JOBS); do
+    JOB_ID=$(qsub <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
-#PBS -N atlas_mc_batch
+#PBS -N atlas_mc_batch_${i}
 #PBS -o ${LOG_DIR}/
 #PBS -e ${LOG_DIR}/
 #PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
 #PBS -l io=5
 #PBS -l walltime=${WALLTIME}
-#PBS -J 1-${NUM_JOBS}
 
 cd ${PIPELINE_DIR}
 
@@ -60,27 +60,36 @@ source ${PIPELINE_DIR}/atlasenv/bin/activate
 python -u main.py --config "${CONFIG}" \
     --tasks parsing,mass_calculating,post_processing \
     --parse-mc true \
-    --batch-job-index \${PBS_ARRAY_INDEX} \
+    --batch-job-index ${i} \
     --total-batch-jobs ${NUM_JOBS} \
     --run-dir "${RUN_DIR}" \
-    > "${LOG_DIR}/batch_\${PBS_ARRAY_INDEX}.out" \
-    2> "${LOG_DIR}/batch_\${PBS_ARRAY_INDEX}.err"
+    > "${LOG_DIR}/batch_${i}.out" \
+    2> "${LOG_DIR}/batch_${i}.err"
 EOF
-)
-echo "Submitted MC batch array: ${ARRAY_JOB_ID}"
+    )
+    echo "Submitted batch ${i}: ${JOB_ID}"
+    if [ -z "$BATCH_JOB_IDS" ]; then
+        BATCH_JOB_IDS="${JOB_ID}"
+    else
+        BATCH_JOB_IDS="${BATCH_JOB_IDS}:${JOB_ID}"
+    fi
+done
 
-# Stages 2-4 identical to data script
-SCAN_JOB_ID=$(qsub -W depend=afterok:"${ARRAY_JOB_ID}" <<EOF
+echo "All batch jobs: ${BATCH_JOB_IDS}"
+
+# Stage 2: scan — depends on ALL batch jobs
+SCAN_JOB_ID=$(qsub -W depend=afterok:"${BATCH_JOB_IDS}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
 #PBS -N atlas_mc_scan
 #PBS -o ${LOG_DIR}/
 #PBS -e ${LOG_DIR}/
-#PBS -l select=1:ncpus=2:mem=32gb
+#PBS -l select=1:ncpus=2:mem=64gb
 #PBS -l io=5
 #PBS -l walltime=${SCAN_WALLTIME}
 
 cd ${PIPELINE_DIR}
+
 export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
 lsetup "views LCG_107 x86_64-el9-gcc14-opt"
@@ -93,19 +102,23 @@ python -u main.py --config "${CONFIG}" \
     2> "${LOG_DIR}/scan.err"
 EOF
 )
+echo "Submitted scan: ${SCAN_JOB_ID} (depends on all batches)"
 
-HIST_JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
+# Stage 3: histogram jobs — each depends on scan
+HIST_JOB_IDS=""
+for i in $(seq 1 $NUM_JOBS); do
+    JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
-#PBS -N atlas_mc_hist
+#PBS -N atlas_mc_hist_${i}
 #PBS -o ${LOG_DIR}/
 #PBS -e ${LOG_DIR}/
 #PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
 #PBS -l io=5
 #PBS -l walltime=${HIST_WALLTIME}
-#PBS -J 1-${NUM_JOBS}
 
 cd ${PIPELINE_DIR}
+
 export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
 lsetup "views LCG_107 x86_64-el9-gcc14-opt"
@@ -113,15 +126,25 @@ source ${PIPELINE_DIR}/atlasenv/bin/activate
 
 python -u main.py --config "${CONFIG}" \
     --tasks histogram_creation \
-    --batch-job-index \${PBS_ARRAY_INDEX} \
+    --batch-job-index ${i} \
     --total-batch-jobs ${NUM_JOBS} \
     --run-dir "${RUN_DIR}" \
-    > "${LOG_DIR}/hist_\${PBS_ARRAY_INDEX}.out" \
-    2> "${LOG_DIR}/hist_\${PBS_ARRAY_INDEX}.err"
+    > "${LOG_DIR}/hist_${i}.out" \
+    2> "${LOG_DIR}/hist_${i}.err"
 EOF
-)
+    )
+    echo "Submitted hist ${i}: ${JOB_ID}"
+    if [ -z "$HIST_JOB_IDS" ]; then
+        HIST_JOB_IDS="${JOB_ID}"
+    else
+        HIST_JOB_IDS="${HIST_JOB_IDS}:${JOB_ID}"
+    fi
+done
 
-MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_ID}" <<EOF
+echo "All hist jobs: ${HIST_JOB_IDS}"
+
+# Stage 4: merge — depends on ALL histogram jobs
+MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_IDS}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
 #PBS -N atlas_mc_merge
@@ -132,6 +155,7 @@ MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_ID}" <<EOF
 #PBS -l walltime=${MERGE_WALLTIME}
 
 cd ${PIPELINE_DIR}
+
 export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
 lsetup "views LCG_107 x86_64-el9-gcc14-opt"
@@ -144,12 +168,16 @@ python -u main.py --config "${CONFIG}" \
     2> "${LOG_DIR}/merge.err"
 EOF
 )
+echo "Submitted merge: ${MERGE_JOB_ID} (depends on all hist jobs)"
 
 echo ""
 echo "Job chain:"
-echo "  Batch:      ${ARRAY_JOB_ID}"
+echo "  Batches:    ${BATCH_JOB_IDS}"
 echo "  Scan:       ${SCAN_JOB_ID}"
-echo "  Histograms: ${HIST_JOB_ID}"
+echo "  Histograms: ${HIST_JOB_IDS}"
 echo "  Merge:      ${MERGE_JOB_ID}"
 echo ""
-echo "MC run dir: ${RUN_DIR}"
+echo "Monitor:  qstat -u \$USER"
+echo "Logs:     ${LOG_DIR}/"
+echo "Output:   ${RUN_DIR}/"
+echo ""

--- a/submit_mc.sh
+++ b/submit_mc.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# ===========================================================================
+# Submit MC pipeline (parse_mc: true)
+# Run after submit_data.sh completes (or independently)
+# ===========================================================================
+
+set -e
+
+NUM_JOBS=12
+CONFIG="configWmaxTotal_up4j_minEvt100_subleading.yaml"
+CPUS_PER_JOB=4
+MEM_PER_JOB="180gb"
+WALLTIME="72:00:00"
+SCAN_WALLTIME="04:00:00"
+HIST_WALLTIME="24:00:00"
+MERGE_WALLTIME="04:00:00"
+QUEUE="N"
+
+PIPELINE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+read RUN_NAME BASE_DIR <<< $(python3 -c "
+import yaml
+with open('${CONFIG}') as f:
+    c = yaml.safe_load(f)
+m = c.get('run_metadata', {})
+print(m.get('run_name', 'pipeline_run'), m.get('base_output_dir', './output'))")
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RUN_DIR="${BASE_DIR}/${RUN_NAME}_mc_${TIMESTAMP}"
+LOG_DIR="${RUN_DIR}/logs"
+mkdir -p "${LOG_DIR}"
+
+cp "${PIPELINE_DIR}/${CONFIG}" "${LOG_DIR}/"
+cp "${PIPELINE_DIR}/submit_mc.sh" "${LOG_DIR}/"
+
+echo "=============================================="
+echo "ATLAS Pipeline — MC submission"
+echo "Run dir: ${RUN_DIR}"
+echo "=============================================="
+
+# Stage 1: parsing + mass_calc + post_processing (MC only)
+ARRAY_JOB_ID=$(qsub <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_mc_batch
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
+#PBS -l io=5
+#PBS -l walltime=${WALLTIME}
+#PBS -J 1-${NUM_JOBS}
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py --config "${CONFIG}" \
+    --tasks parsing,mass_calculating,post_processing \
+    --parse-mc true \
+    --batch-job-index \${PBS_ARRAY_INDEX} \
+    --total-batch-jobs ${NUM_JOBS} \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/batch_\${PBS_ARRAY_INDEX}.out" \
+    2> "${LOG_DIR}/batch_\${PBS_ARRAY_INDEX}.err"
+EOF
+)
+echo "Submitted MC batch array: ${ARRAY_JOB_ID}"
+
+# Stages 2-4 identical to data script
+SCAN_JOB_ID=$(qsub -W depend=afterok:"${ARRAY_JOB_ID}" <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_mc_scan
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=2:mem=32gb
+#PBS -l io=5
+#PBS -l walltime=${SCAN_WALLTIME}
+
+cd ${PIPELINE_DIR}
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py --config "${CONFIG}" \
+    --scan-only \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/scan.out" \
+    2> "${LOG_DIR}/scan.err"
+EOF
+)
+
+HIST_JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_mc_hist
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
+#PBS -l io=5
+#PBS -l walltime=${HIST_WALLTIME}
+#PBS -J 1-${NUM_JOBS}
+
+cd ${PIPELINE_DIR}
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py --config "${CONFIG}" \
+    --tasks histogram_creation \
+    --batch-job-index \${PBS_ARRAY_INDEX} \
+    --total-batch-jobs ${NUM_JOBS} \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/hist_\${PBS_ARRAY_INDEX}.out" \
+    2> "${LOG_DIR}/hist_\${PBS_ARRAY_INDEX}.err"
+EOF
+)
+
+MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_ID}" <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_mc_merge
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=2:mem=32gb
+#PBS -l io=5
+#PBS -l walltime=${MERGE_WALLTIME}
+
+cd ${PIPELINE_DIR}
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py --config "${CONFIG}" \
+    --merge-only \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/merge.out" \
+    2> "${LOG_DIR}/merge.err"
+EOF
+)
+
+echo ""
+echo "Job chain:"
+echo "  Batch:      ${ARRAY_JOB_ID}"
+echo "  Scan:       ${SCAN_JOB_ID}"
+echo "  Histograms: ${HIST_JOB_ID}"
+echo "  Merge:      ${MERGE_JOB_ID}"
+echo ""
+echo "MC run dir: ${RUN_DIR}"

--- a/submit_mc.sh
+++ b/submit_mc.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # ===========================================================================
 # Submit MC pipeline (parse_mc: true)
+#
+# Job chain:
+#   batch array (parsing+mass_calculating) → postproc (single job) →
+#   scan → histogram array → merge
 # ===========================================================================
 
 set -e
@@ -10,6 +14,7 @@ CONFIG="configWmaxTotal_up4j_minEvt10_subleading.yaml"
 CPUS_PER_JOB=4
 MEM_PER_JOB="180gb"
 WALLTIME="12:00:00"
+POSTPROC_WALLTIME="24:00:00"
 SCAN_WALLTIME="04:00:00"
 HIST_WALLTIME="24:00:00"
 MERGE_WALLTIME="04:00:00"
@@ -37,7 +42,7 @@ echo "ATLAS Pipeline — MC submission"
 echo "Run dir: ${RUN_DIR}"
 echo "=============================================="
 
-# Stage 1: submit N individual batch jobs (parsing+mass_calc+post_processing)
+# Stage 1: parsing + mass_calculating only (per batch)
 BATCH_JOB_IDS=""
 for i in $(seq 1 $NUM_JOBS); do
     JOB_ID=$(qsub <<EOF
@@ -58,7 +63,7 @@ lsetup "views LCG_107 x86_64-el9-gcc14-opt"
 source ${PIPELINE_DIR}/atlasenv/bin/activate
 
 python -u main.py --config "${CONFIG}" \
-    --tasks parsing,mass_calculating,post_processing \
+    --tasks parsing,mass_calculating \
     --parse-mc true \
     --batch-job-index ${i} \
     --total-batch-jobs ${NUM_JOBS} \
@@ -68,17 +73,39 @@ python -u main.py --config "${CONFIG}" \
 EOF
     )
     echo "Submitted batch ${i}: ${JOB_ID}"
-    if [ -z "$BATCH_JOB_IDS" ]; then
-        BATCH_JOB_IDS="${JOB_ID}"
-    else
-        BATCH_JOB_IDS="${BATCH_JOB_IDS}:${JOB_ID}"
-    fi
+    BATCH_JOB_IDS="${BATCH_JOB_IDS:+${BATCH_JOB_IDS}:}${JOB_ID}"
 done
-
 echo "All batch jobs: ${BATCH_JOB_IDS}"
 
-# Stage 2: scan — depends on ALL batch jobs
-SCAN_JOB_ID=$(qsub -W depend=afterok:"${BATCH_JOB_IDS}" <<EOF
+# Stage 2: post-processing — single job reading ALL im_batch_*.sqlite files
+POSTPROC_JOB_ID=$(qsub -W depend=afterok:"${BATCH_JOB_IDS}" <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_mc_postproc
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=4:mem=64gb
+#PBS -l io=5
+#PBS -l walltime=${POSTPROC_WALLTIME}
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py --config "${CONFIG}" \
+    --tasks post_processing \
+    --run-dir "${RUN_DIR}" \
+    > "${LOG_DIR}/postproc.out" \
+    2> "${LOG_DIR}/postproc.err"
+EOF
+)
+echo "Submitted postproc: ${POSTPROC_JOB_ID} (depends on all batches)"
+
+# Stage 3: scan global ranges — depends on postproc
+SCAN_JOB_ID=$(qsub -W depend=afterok:"${POSTPROC_JOB_ID}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
 #PBS -N atlas_mc_scan
@@ -102,9 +129,9 @@ python -u main.py --config "${CONFIG}" \
     2> "${LOG_DIR}/scan.err"
 EOF
 )
-echo "Submitted scan: ${SCAN_JOB_ID} (depends on all batches)"
+echo "Submitted scan: ${SCAN_JOB_ID} (depends on postproc)"
 
-# Stage 3: histogram jobs — each depends on scan
+# Stage 4: histogram creation — per batch, depends on scan
 HIST_JOB_IDS=""
 for i in $(seq 1 $NUM_JOBS); do
     JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
@@ -134,16 +161,11 @@ python -u main.py --config "${CONFIG}" \
 EOF
     )
     echo "Submitted hist ${i}: ${JOB_ID}"
-    if [ -z "$HIST_JOB_IDS" ]; then
-        HIST_JOB_IDS="${JOB_ID}"
-    else
-        HIST_JOB_IDS="${HIST_JOB_IDS}:${JOB_ID}"
-    fi
+    HIST_JOB_IDS="${HIST_JOB_IDS:+${HIST_JOB_IDS}:}${JOB_ID}"
 done
-
 echo "All hist jobs: ${HIST_JOB_IDS}"
 
-# Stage 4: merge — depends on ALL histogram jobs
+# Stage 5: merge — depends on ALL histogram jobs
 MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_IDS}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
@@ -173,6 +195,7 @@ echo "Submitted merge: ${MERGE_JOB_ID} (depends on all hist jobs)"
 echo ""
 echo "Job chain:"
 echo "  Batches:    ${BATCH_JOB_IDS}"
+echo "  Postproc:   ${POSTPROC_JOB_ID}"
 echo "  Scan:       ${SCAN_JOB_ID}"
 echo "  Histograms: ${HIST_JOB_IDS}"
 echo "  Merge:      ${MERGE_JOB_ID}"
@@ -180,4 +203,3 @@ echo ""
 echo "Monitor:  qstat -u \$USER"
 echo "Logs:     ${LOG_DIR}/"
 echo "Output:   ${RUN_DIR}/"
-echo ""

--- a/submit_parsing_only.sh
+++ b/submit_parsing_only.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# ===========================================================================
+# submit_parsing_only.sh
+#
+# Step 1: Run ONLY the parsing stage in a single job.
+#         Mass calculation is intentionally excluded — run separately
+#         after all data is parsed using submit_mass_calc.sh
+#
+# Usage:
+#   bash submit_parsing_only.sh
+# ===========================================================================
+
+set -e
+
+CONFIG="config10GeVbin.yaml"
+CPUS_PER_JOB=4
+MEM_PER_JOB="20gb"
+WALLTIME="72:00:00"
+QUEUE="N"
+
+PIPELINE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- Set run name and base dir directly (avoids YAML anchor issues) ------
+# Edit these two values to match your config.yaml
+RUN_NAME="atlas_full_fixComb_fixCut"
+BASE_DIR="/storage/agrp/marybo/DDP/BumpNet4AtlasOpenData/data"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RUN_DIR="${BASE_DIR}/${RUN_NAME}_${TIMESTAMP}"
+LOG_DIR="${RUN_DIR}/logs"
+mkdir -p "${LOG_DIR}"
+
+cp "${PIPELINE_DIR}/${CONFIG}" "${LOG_DIR}/"
+cp "${PIPELINE_DIR}/submit_parsing_only.sh" "${LOG_DIR}/"
+
+echo "=============================================="
+echo "ATLAS Pipeline — Parsing Only"
+echo "=============================================="
+echo "Config   : ${CONFIG}"
+echo "Run dir  : ${RUN_DIR}"
+echo "Walltime : ${WALLTIME}"
+echo "=============================================="
+echo ""
+echo "After parsing completes, run mass calculation with:"
+echo "  RUN_DIR=${RUN_DIR} bash submit_mass_calc.sh"
+echo ""
+
+JOB_ID=$(qsub <<EOF
+#!/bin/bash
+#PBS -q ${QUEUE}
+#PBS -N atlas_parsing
+#PBS -o ${LOG_DIR}/
+#PBS -e ${LOG_DIR}/
+#PBS -l select=1:ncpus=${CPUS_PER_JOB}:mem=${MEM_PER_JOB}
+#PBS -l io=5
+#PBS -l walltime=${WALLTIME}
+
+cd ${PIPELINE_DIR}
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+lsetup "views LCG_107 x86_64-el9-gcc14-opt"
+
+source ${PIPELINE_DIR}/atlasenv/bin/activate
+
+python -u main.py \
+    --config "${CONFIG}" \
+    --run-dir "${RUN_DIR}" \
+    --tasks parsing \
+    > "${LOG_DIR}/parsing.out" \
+    2> "${LOG_DIR}/parsing.err"
+EOF
+)
+
+echo "Submitted: ${JOB_ID}"
+echo "Run dir  : ${RUN_DIR}"
+echo ""
+echo "Monitor  : qstat -u \$USER"
+echo "Log      : tail -f ${LOG_DIR}/parsing.out"

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -95,6 +95,8 @@ def update_config_paths_with_run_dir(config_dict: dict, run_dir: str) -> dict:
         hist_config = updated_config['histogram_creation_task_config']
         _set_if_relative(hist_config, 'input_dir', os.path.join(run_dir, "im_arrays_processed"))
         _set_if_relative(hist_config, 'output_dir', os.path.join(run_dir, "histograms"))
+        # Always set global_ranges_path — scan job writes here, histogram batches read from here
+        hist_config['global_ranges_path'] = os.path.join(run_dir, "logs", "global_ranges.json")
 
     return updated_config
 


### PR DESCRIPTION
# ATLAS Open Data → BumpNet Pipeline

This branch contains fixes and extensions to the ATLAS utilization pipeline
for processing ATLAS Open Data PHYSLITE files and producing invariant mass
histograms for the BumpNet anomaly detection algorithm.

## Branch: `atlas-opendata-bumpnet`

Based on: `master` of [atlas-utilization](https://github.com/Zhavi221/atlas-utilization)

---

## Summary of Changes

### Fix 17 — Histogram batch jobs not splitting SQLite files correctly (`histograms_pipeline.py`, `orchestration/handlers/histogram_creation_handler.py`, `main.py`, `domain/config.py`)

**Problem:** Multiple issues caused all histogram batch jobs to process all
processed SQLite files instead of their assigned slice, producing identical
histograms in each batch that hadd summed incorrectly:

1. `total_batch_jobs` was missing from the `config_dict` passed to
   `create_histograms` — without it, `_create_histograms_from_sqlite` could
   not split SQLite files by batch index.

2. `global_ranges_path` was not passed through `HistogramCreationHandler` to
   `create_histograms`, so `global_ranges` was always `None` and histograms
   used batch-local bin edges instead of the global ones from `global_ranges.json`.

3. `_create_histograms_from_sqlite` had no SQLite file splitting logic at all —
   it always read all SQLite files regardless of `batch_job_index`.

4. `batch_job_index` and `total_batch_jobs` were injected into
   `histogram_creation_task_config` in `main.py` but only after
   `update_config_paths_with_run_dir` was called, so the split never reached
   `PipelineConfig`.

5. `also_save_pre_postproc`, `pre_postproc_filename`, and `global_ranges_path`
   were not defined as fields in `HistogramCreationConfig` or read in
   `from_dict`, so YAML values were silently ignored.

**Fixes:**

- `histograms_pipeline.py`: added SQLite file splitting in
  `_create_histograms_from_sqlite` using `_get_batch_files` when
  `batch_job_index` and `total_batch_jobs` are present in config.

- `histogram_creation_handler.py`: added `total_batch_jobs` and
  `global_ranges_path` to the `config_dict` passed to `create_histograms`.

- `main.py`: inject `batch_job_index` and `total_batch_jobs` into
  `histogram_creation_task_config` alongside `output_filename`.

- `domain/config.py`: added `global_ranges_path`, `also_save_pre_postproc`,
  and `pre_postproc_filename` fields to `HistogramCreationConfig` dataclass
  and wired them through `from_dict`.


### Fix 12 — Histogram bin-edge mismatch across batches (`histograms_pipeline.py`, `executor.py`, `utils/paths.py`)

**Problem:** Each histogram batch job computed `global_min`/`global_max` from its
own data slice, producing histograms with different bin edges per batch. `hadd`
silently kept only the first batch's histogram and discarded the rest — e.g. for
`mass_m0m1j0_cat_2mx_1jx`, batch_1 had `nbins=33 min=59.8 max=397.5` while
batch_3 had `nbins=254 min=62.3 max=2598.7`. The merged file contained only
batch_1's 33 events instead of the true ~52,000.

**Fix:** Introduced a mandatory scan step between post-processing and histogram
creation. The scan reads all processed SQLite files, computes the true global
min/max per bumpnet signature across all batches and chunks, and writes
`logs/global_ranges.json`. All histogram batch jobs load this file and use
identical bin edges. `hadd` now merges correctly.

**New `--scan-only` mode** in `main.py` + `scan_global_ranges()` in `executor.py`:
```bash
python main.py --scan-only --run-dir /path/to/run_dir
```

**New helper functions** in `histograms_pipeline.py`:
```python
compute_global_ranges(sqlite_files, input_dir, exclude_outliers)
save_global_ranges(ranges, output_path)
load_global_ranges(path)
```

**`utils/paths.py`:** `update_config_paths_with_run_dir` now always sets
`global_ranges_path = {run_dir}/logs/global_ranges.json` automatically — no
manual config change needed.

**PBS job chain updated** (`submit_data.sh`, `submit_mc.sh`):

---

### Fix 13 — MC/data contamination in pipeline runs (`submit_data.sh`, `submit_mc.sh`, `main.py`)

**Problem:** Data and MC files were parsed into the same run directory. With
`parse_mc=False` the metadata cache still contained MC URLs (see Fix 11), and
the pipeline had no clean mechanism to enforce full separation at the run level.

**Fix:** Separated into two independent submission scripts:
- `submit_data.sh` — creates `{run_name}_data_{TIMESTAMP}/`, passes `--parse-mc false`
- `submit_mc.sh` — creates `{run_name}_mc_{TIMESTAMP}/`, passes `--parse-mc true`

Both scripts use the same config file. A new `--parse-mc true/false` CLI flag
overrides `parse_mc` in `parsing_task_config` at runtime without editing YAML:

```bash
# in submit_data.sh:
python -u main.py --config "${CONFIG}" --parse-mc false ...

# in submit_mc.sh:
python -u main.py --config "${CONFIG}" --parse-mc true ...
```

Both scripts implement the full 4-stage PBS chain from Fix 12.

---

### Fix 14 — Batch file deletion after hadd destroyed retry runs (`executor.py`)

**Problem:** `merge_outputs` called `bf.unlink()` on each `batch_N.root` file
after a successful `hadd`. On retry runs (e.g. after a failed batch job was
resubmitted), only the new batch file existed — `hadd` merged just 1 file instead
of all N, silently overwriting the previously correct merged file.

**Fix:** Batch files are now moved to `histograms/batch_files_archive/` instead
of deleted:
```python
archive_dir = Path(hist_dir) / "batch_files_archive"
archive_dir.mkdir(exist_ok=True)
for bf in batch_roots:
    bf.rename(archive_dir / bf.name)
```

---

### Fix 15 — Stats aggregation crash on float-valued fields (`executor.py`)

**Problem:** `_aggregate_batch_stats` called `int(p[key])` on fields like
`total_size_mb` which are stored as floats (e.g. `'0.00'`), raising
`ValueError: invalid literal for int() with base 10: '0.00'`.

**Fix:** `int(float(p[key]))` — converts to float first, then truncates to int.

---

### Fix 16 — Memory crash in plot generation (`executor.py`)

**Problem:** `_read_parsed_data_stats` accumulated full per-event particle count
arrays (`particle_dists[ptype].extend(counts.tolist())`) across all 671 parsed
ROOT files. With millions of events per file this exhausted memory on the login
node, killing the process silently with no traceback.

**Fix:** Replaced array accumulation with immediate summation:
```python
counts = tree[branch_name].array(library="np")
particle_counts[ptype] = particle_counts.get(ptype, 0) + int(np.sum(counts))
del counts  # free immediately
```
`distributions` dict is now always empty — too large to store for runs of this size.

---

### Feature — Pre-post-processing histograms (`executor.py`, `histogram_creation_task_config`)

**Motivation:** Comparing histograms before and after post-processing is essential
for validating peak removal. 
**New config options:**
```yaml
histogram_creation_task_config:
  also_save_pre_postproc: true
  pre_postproc_filename: "atlas_opendata_nopostproc.root"
```

When enabled, the merge job reads all `im_arrays/*.sqlite` files (raw invariant
mass arrays, before peak removal) and writes a second ROOT file alongside the
main post-processed one. Produced in the merge step to avoid the bin-edge problem
— all data is visible at once, no batching required.

## Fix 11 — prevent MC/data contamination in metadata cache

**Problem:**The previous `_separate_mc_files` used `"mc" in url.lower()` which is
ambiguous — ATLAS Open Data URLs all contain "opendata", causing MC URLs
to be misclassified. With `parse_mc=False`, no separation happened at
all, so MC events were silently parsed as collision data.

**Modified files:**:
- fetcher.py: replace loose substring match with regex-based classifier
  (_classify_url) anchored to the dataset namespace component (mc<N>_,
  data<N>_). Separation now always happens unconditionally. Unclassifiable
  URLs raise ValueError immediately — no silent misrouting.
- fetcher.py: add _assert_no_cross_contamination() post-separation check
  as a safety net.
- fetch_metadata_handler.py: validate cache integrity on load; raise
  RuntimeError with first 5 violations if contaminated, forcing cache
  rebuild. Remove separate_mc argument from fetcher.fetch() call.
- parsing_handler.py: skip keys ending in _mc when parse_mc=False.
  parse_mc now means "include MC in the parsing run", not "separate in
  cache" (separation is always performed).
  
## Fix 10 — Sub-leading particle support

**Problem:** All combinations used only leading particles (highest pT).
`{"Electrons": 1}` always meant e₀. There was no way to compute e₁+j₀
(sub-leading electron + leading jet) as a separate invariant mass signature.

**Solution:** Combination values are now `(count, start_index)` tuples.
`start_index=0` = leading (unchanged behaviour); `start_index=1` = sub-leading.
Plain `int` values are still accepted via `get_count()` / `get_start()` helpers
for full backward compatibility.

**New config flags** (in `mass_calculation_task_config`):
```yaml
include_subleading: false   # set true to activate
max_subleading_index: 1     # highest rank index (1 = up to sub-leading)
```

**Impact:** With `max_subleading_index: 1`, enabling sub-leading expands
combinations from 65 → 308 (~4.7×). Walltime should be scaled accordingly.

**Modified files:** `combinatorics.py`, `physics_calcs.py`,
`im_calculator.py`, `im_pipeline.py`, `domain/config.py`, `config.yaml`

############################

### Fix 5 — max_total_particles_in_combination cap (`combinatorics.py`, `domain/config.py`, `mass_calculation_handler.py`)

**Problem:** With `min_particles_in_combination: 1`, the number of IM combinations
explodes to 624 (4 particle types, counts 1–4 each, no cap). Most high-multiplicity
combinations (e.g. 4e+4μ+4j+4γ = 16 particles) are unphysical and produce
negligible statistics, wasting mass calculation time.

**Fix:** Added `max_total_particles_in_combination` parameter that skips any
combination where the sum of particle counts exceeds the cap:

```python
# services/calculations/combinatorics.py
for counts in itertools.product(*count_ranges):
    if sum(counts) > max_total_particles:   # skip combinations exceeding particle cap
        continue
```

Configurable via yaml:
```yaml
mass_calculation_task_config:
  max_total_particles_in_combination: 4  # default; reduces 624 → 69 combinations
```

---

### Fix 6 — Post-processing: merge all chunks by FS_IM key before peak detection (`post_processing_pipeline.py`)

**Problem:** The post-processing pipeline iterated over individual signatures like
`parsed_2024r-pp_batch1_chunk0_FS_0e_0m_3j_0g_IM_j0j1j2`, processing each chunk
independently. This caused the peak finder to see partial distributions (e.g.
250k events from one chunk) rather than the full merged distribution (~2.5M
events across all chunks and batches). On sparse per-chunk distributions the
highest bin was often the low-mass turn-on, not the Z peak — leading to incorrect
peak removal.

**Fix:** Group all signatures by their `FS_IM` key (stripping the
`parsed_..._batch{N}_chunk{M}` prefix) before peak detection, then load and
concatenate all chunk arrays for that key:

```python
from collections import defaultdict
fs_im_groups = defaultdict(list)
for sig in signatures:
    m = re.search(r'(_FS_.+)', sig)
    fs_im_key = m.group(1) if m else sig
    fs_im_groups[fs_im_key].append(sig)

for fs_im_key in sorted(fs_im_groups.keys()):
    chunks = []
    for sig in fs_im_groups[fs_im_key]:
        for filename in sqlite_files:
            chunks.extend(iter_arrays_for_signature(..., sig))
    arr = np.concatenate(chunks)
    # peak detection on full merged array
```

**Result:** Peak detection now operates on the complete merged distribution,
correctly identifying the Z peak at ~91 GeV even for sparse final states.

---

### Fix 7 — Post-processing: use right edge of peak bin (`post_processing_pipeline.py`)

remove Fix 7 — peak bin right-edge shift had no effect

The peak_bin_idx + 1 change (right edge instead of left edge of peak bin)
did not solve the post-processing problem. Root cause is elsewhere.
Reverting to original behavior pending proper fix.

---

### Fix 8 — Post-processing: periodic SQLite commits (`post_processing_pipeline.py`)

**Problem:** The original code called `writer.commit()` only once after processing
all signatures. With 3.7M signatures this produced an 8 GB SQLite WAL file that
was rolled back entirely on job kill — losing all progress.

**Fix:** Commit every 1000 signatures:

```python
COMMIT_EVERY = 1000
processed = 0
for fs_im_key in sorted(fs_im_groups.keys()):
    # ... process ...
    processed += 1
    if processed % COMMIT_EVERY == 0:
        writer.commit()
        logger.info(f"Post-processing progress: {processed}/{len(fs_im_groups)} signatures committed")
writer.commit()  # final commit for remainder
```

**Result:** WAL stays small (~few MB), and at most 1000 signatures worth of work
is lost on job kill.

### Fix 9 — Skip single-particle combinations in combinatorics (`combinatorics.py`)

Added a guard in `get_all_combinations` to reject combinations where the total
particle count is less than 2. A single-particle "combination" produces a trivial
invariant mass equal to the particle's own mass, which is physically meaningless
for bump hunting. Previously, such combinations could pass the `max_total_particles`
filter and propagate through the mass calculation, generating spurious signatures
(e.g. `1e_0m_0j_0g`) that inflate the histogram count without any signal sensitivity.

**Change:** `if sum(counts) < 2: continue`
**Result:** Combinatorics now only generates signatures with ≥ 2 particles

---

### Fix 1 — Index-based IM naming (`im_pipeline.py`, `histograms_pipeline.py`)

**Problem:** The pipeline used count-based naming for invariant mass combinations,
e.g. `IM_2e_0m_1j_0g`, which is ambiguous — it does not specify *which* particles
were used (leading vs sub-leading). BumpNet expects index-based naming starting
from 0 (e.g. `e0`, `e1`, `j0`).

**Fix:** Two functions were updated:
- `prepare_im_combination_name` in `services/pipelines/im_pipeline.py`
- `_convert_to_bumpnet_name` in `services/pipelines/histograms_pipeline.py`

**Result:**

| Old signature | New signature | Meaning |
|---|---|---|
| `IM_1e_0m_1j_0g` | `IM_e0j0` | leading e + leading j (2-body) |
| `IM_2e_0m_1j_0g` | `IM_e0e1j0` | both e + leading j (3-body) |
| `IM_1e_0m_2j_0g` | `IM_e0j0j1` | leading e + both j (3-body) |

Histogram names follow the same convention:
`ROI_mass_e0j0_cat_1ex_0mx_1jx_0gx_width_10.0`

---

### Fix 2 — Kinematic cuts in MeV (`config.yaml`)

**Problem:** ATLAS PHYSLITE stores all 4-vector quantities (pt, mass, energy) in
MeV. The original config used `pt_min: 25.0`, which meant 25 MeV — effectively
no cut, passing all soft particles and producing unphysical invariant masses.

**Fix:** Config updated to use MeV values:

```yaml
kinematic_cuts:
  electrons: { pt_min: 25000.0, eta_max: 2.47 }  # 25 GeV in MeV
  muons:     { pt_min: 25000.0, eta_max: 2.5  }
  jets:      { pt_min: 30000.0, eta_max: 4.5  }
  photons:   { pt_min: 25000.0, eta_max: 2.37 }
```

The `_convert_array_to_gev()` function (`* 1e-3`) in `im_pipeline.py` correctly
converts MeV → GeV for the final invariant mass values stored in SQLite.

---

### Fix 3 — Memory leak in `parsing_handler.py`

**Problem:** After writing each parsed ROOT chunk to disk, the Python `EventChunk`
object (holding large awkward arrays) was not explicitly freed. Python's garbage
collector does not release memory promptly, causing memory to grow continuously
throughout a long parsing job — reaching 150+ GB for a 72-hour run over 70,201
files.

**Fix:** Added explicit memory release after each chunk write:

```python
import gc

# After _save_chunk_to_root(chunk, ...):
del chunk
gc.collect()

# After _save_chunk_to_root(final_chunk, ...):
del final_chunk
gc.collect()
```

The ROOT files on disk are unaffected — only the in-memory Python object is freed.








