### PR TITLE
Better b-tagging Support

### DIFF
--- a/config.short_parse_btag.yaml
+++ b/config.short_parse_btag.yaml
@@ -74,8 +74,9 @@ parsing_task_config:
       pt_min: 25.0
       eta_max: 2.37
   enable_jet_tagging: true
-  jet_btag_field: btagDeepFlavB
-  jet_btag_threshold: 0.5
+  jet_btagging_thresholds:
+    btagDeepFlavB: 0.5
+    DL1d: 2.51
 mass_calculation_task_config:
   input_dir: /storage/agrp/netalev/data/atlas_pp_root_files
   output_dir: ./output/im_arrays

--- a/config.yaml
+++ b/config.yaml
@@ -88,9 +88,10 @@ parsing_task_config:
   count_retries_failed_files: 3
   fetching_metadata_timeout: 60
   max_files_to_process: null             # null = all files; set e.g. 3 for a quick test
-  enable_jet_tagging: false              # when true, split Jets into BJets/LJets if btag field exists
-  jet_btag_field: "btagDeepFlavB"        # field read from Jets collection
-  jet_btag_threshold: 0.5                # score >= threshold -> BJets
+  enable_jet_tagging: false              # when true, split Jets into BJets/LJets. Must give thresholds for btagging discriminants!
+  jet_btagging_thresholds:
+    btagDeepFlavB: 0.5
+    DL1d: 2.51
 
   # ===ROOT TREES===
   possible_data_tree_names:

--- a/domain/config.py
+++ b/domain/config.py
@@ -56,8 +56,7 @@ class ParsingConfig:
     possible_data_tree_names: tuple[str, ...] = ("CollectionTree",)
     max_files_to_process: Optional[int] = None  # Limit files (for testing)
     enable_jet_tagging: bool = False
-    jet_btag_field: str = "btagDeepFlavB"
-    jet_btag_threshold: float = 0.5
+    jet_btagging_thresholds: Optional[dict] = None
 
     # Optional selection (from YAML): applied after reading each file, before chunking
     particle_counts: Optional[dict] = None
@@ -81,6 +80,9 @@ class ParsingConfig:
             raise ValueError("jobs_logs_path cannot be empty")
         if not isinstance(self.enable_jet_tagging, bool):
             raise ValueError("enable_jet_tagging must be a boolean")
+        if self.enable_jet_tagging and not self.jet_btagging_thresholds:
+            # TODO add algorithm-specific validation
+            raise ValueError("jet_btagging_thresholds must be specified when enable_jet_tagging is set")
 
 
 @dataclass(frozen=True)
@@ -296,8 +298,7 @@ class PipelineConfig:
                 possible_data_tree_names=tuple(parsing_dict.get("possible_data_tree_names", ["CollectionTree"])),
                 max_files_to_process=parsing_dict.get("max_files_to_process"),
                 enable_jet_tagging=parsing_dict.get("enable_jet_tagging", False),
-                jet_btag_field=parsing_dict.get("jet_btag_field", "btagDeepFlavB"),
-                jet_btag_threshold=parsing_dict.get("jet_btag_threshold", 0.5),
+                jet_btagging_thresholds=parsing_dict.get("jet_btagging_thresholds", None),
                 particle_counts=parsing_dict.get("particle_counts"),
                 kinematic_cuts=parsing_dict.get("kinematic_cuts"),
             )

--- a/orchestration/handlers/parsing_handler.py
+++ b/orchestration/handlers/parsing_handler.py
@@ -161,8 +161,7 @@ class ParsingHandler(StateHandler):
                 release_year=release_year,
                 batch_size=40_000,
                 enable_jet_tagging=parsing_config.enable_jet_tagging,
-                jet_btag_field=parsing_config.jet_btag_field,
-                jet_btag_threshold=parsing_config.jet_btag_threshold,
+                jet_btagging_thresholds=parsing_config.jet_btagging_thresholds,
                 on_success=on_success,
                 on_error=on_error
             ):

--- a/services/parsing/file_parser.py
+++ b/services/parsing/file_parser.py
@@ -30,8 +30,7 @@ class FileParser:
         release_year: str,
         batch_size: int = 40_000,
         enable_jet_tagging: bool = False,
-        jet_btag_field: str = "btagDeepFlavB",
-        jet_btag_threshold: float = 0.5,
+        jet_btagging_thresholds: Optional[dict[str, float]] = None,
     ) -> Optional[ak.Array]:
         """
         Parse a single ROOT file and return events.
@@ -54,8 +53,7 @@ class FileParser:
                     batch_size,
                     file_path,
                     enable_jet_tagging,
-                    jet_btag_field,
-                    jet_btag_threshold,
+                    jet_btagging_thresholds,
                 )
         except Exception as e:
             logging.warning(f"Failed to open file {file_path}: {e}")
@@ -69,8 +67,7 @@ class FileParser:
         batch_size: int,
         file_path: str,
         enable_jet_tagging: bool,
-        jet_btag_field: str,
-        jet_btag_threshold: float,
+        jet_btagging_thresholds: Optional[dict[str, float]]
     ) -> Optional[ak.Array]:
         """Parse an already-opened ROOT file."""
         tree_name = FileParser._get_data_tree_name(root_file.keys(), tree_names)
@@ -102,7 +99,7 @@ class FileParser:
             batch_size
         )
         if enable_jet_tagging:
-            obj_events = FileParser._calculate_btagging_and_split(obj_events)
+            obj_events = FileParser._calculate_btagging_and_split(obj_events, jet_btagging_thresholds)
         # Strip out DirectObjects -- they are not physics objects!
         obj_events.pop("DirectObjects")
         return ak.zip(obj_events, depth_limit=1)
@@ -110,17 +107,20 @@ class FileParser:
     @staticmethod
     def _calculate_btagging_and_split(
         obj_events: dict[str, ak.Array],
+        jet_btagging_thresholds: Optional[dict[str, float]]
     ) -> dict[str, ak.Array]:
         """
         For each Jet objects in each event, calculates the b-tagging discriminant.
-        Then, decides if each jet is a bjet or not. If bjet, stores in obj_events["BJet"] and removes from obj_events["Jets"]
-        Otherwise, leaves the Jet be.
+        Then, decides if each jet is a bjet or not, using the per-algorithm threshold in `jet_btagging_thresholds`.
+        If bjet, stores in obj_events["BJet"] and removes from obj_events["Jets"]. Otherwise, leaves the Jet be.
         """
         # TODO Find a cleaner way to determine if dealing with nanoAOD, PHYSLITE, etc.
+        # TODO Maybe add an explicit check if the algorithm-specific threshold exists in the configuration dict before
+        # accessing it. However, I'd rather fail parsing then give false physics data.
         if "Jet_btagDeepFlavB" in obj_events["DirectObjects"].fields:
             # CMS: Discriminant is pre-calculated as the Jet_btagDeepFlavB field. Can change to a different algorithm if needed.
             # See https://cms-opendata-workshop.github.io/workshop2024-lesson-physics-objects/instructor/05-btagging.html
-            is_bjet = obj_events["DirectObjects"]["Jet_btagDeepFlavB"] > 0.5
+            is_bjet = obj_events["DirectObjects"]["Jet_btagDeepFlavB"] > jet_btagging_thresholds["Jet_btagDeepFlavB"]
         elif "BTagging_AntiKt4EMPFlowAuxDyn.DL1dv01_pb" in obj_events["DirectObjects"].fields:
             # ATLAS
             indices = obj_events["DirectObjects"]["AnalysisJetsAuxDyn.btaggingLink/AnalysisJetsAuxDyn.btaggingLink.m_persIndex"]
@@ -130,8 +130,7 @@ class FileParser:
             # DL1d score: log(pb / (fc*pc + (1-fc)*pu)), fc=0.018 is standard ATLAS.
             fc = 0.018
             dl1d = np.log(pb / (fc * pc + (1 - fc) * pu))
-            mask = dl1d > 0
-            is_bjet = dl1d > 2.51
+            is_bjet = dl1d > jet_btagging_thresholds["DL1d"]
         else:
             return obj_events
         obj_events["BJets"] = obj_events["Jets"][is_bjet]

--- a/services/parsing/file_parser.py
+++ b/services/parsing/file_parser.py
@@ -103,6 +103,8 @@ class FileParser:
         )
         if enable_jet_tagging:
             obj_events = FileParser._calculate_btagging_and_split(obj_events)
+        # Strip out DirectObjects -- they are not physics objects!
+        obj_events.pop("DirectObjects")
         return ak.zip(obj_events, depth_limit=1)
 
     @staticmethod

--- a/services/parsing/file_parser.py
+++ b/services/parsing/file_parser.py
@@ -7,6 +7,7 @@ No orchestration logic, no state management.
 
 import logging
 import awkward as ak
+import numpy as np
 import uproot
 import itertools
 from typing import Optional
@@ -81,7 +82,7 @@ class FileParser:
             all_tree_branches,
             release_year
         )
-        
+
         if not obj_branches:
             logging.warning(f"No particles found in schema for file {file_path}")
             return None
@@ -101,33 +102,40 @@ class FileParser:
             batch_size
         )
         if enable_jet_tagging:
-            obj_events = FileParser._split_jets_by_btag(
-                obj_events,
-                btag_field=jet_btag_field,
-                threshold=jet_btag_threshold,
-        )
-        
+            obj_events = FileParser._calculate_btagging_and_split(obj_events)
         return ak.zip(obj_events, depth_limit=1)
 
     @staticmethod
-    def _split_jets_by_btag(
+    def _calculate_btagging_and_split(
         obj_events: dict[str, ak.Array],
-        btag_field: str,
-        threshold: float,
-    ) -> dict[str, ak.Array]:
-        """
-        Optionally split Jets into BJets/LJets using a configurable b-tag score field.
-        """
-        jets = obj_events.get("Jets")
-        if jets is None or btag_field not in jets.fields:
-            return obj_events
 
-        score = jets[btag_field]
-        is_bjet = score >= threshold
-        obj_events["BJets"] = jets[is_bjet]
-        obj_events["Jets"] = jets[~is_bjet]
-        # In tagging mode, treat tagged jets as the canonical jet categories.
-        return obj_events
+    ):
+        """
+        For each Jet objects in each event, calculates the b-tagging discriminant.
+        Then, decides if each jet is a bjet or not. If bjet, stores in obj_events["BJet"] and removes from obj_events["Jets"]
+        Otherwise, leaves the Jet be.
+        """
+        # TODO Find a cleaner way to determine if dealing with nanoAOD, PHYSLITE, etc.
+        if "Jet_btagDeepFlavB" in obj_events["DirectObjects"].fields:
+            # CMS: Discriminant is pre-calculated as the Jet_btagDeepFlavB field. Can change to a different algorithm if needed.
+            # See https://cms-opendata-workshop.github.io/workshop2024-lesson-physics-objects/instructor/05-btagging.html
+            is_bjet = obj_events["DirectObjects"]["Jet_btagDeepFlavB"] > 0.5
+        elif "BTagging_AntiKt4EMPFlowAuxDyn.DL1dv01_pb" in obj_events["DirectObjects"].fields:
+            # ATLAS
+            indices = obj_events["DirectObjects"]["AnalysisJetsAuxDyn.btaggingLink/AnalysisJetsAuxDyn.btaggingLink.m_persIndex"]
+            pb = obj_events["DirectObjects"]["BTagging_AntiKt4EMPFlowAuxDyn.DL1dv01_pb"][indices]
+            pc = obj_events["DirectObjects"]["BTagging_AntiKt4EMPFlowAuxDyn.DL1dv01_pc"][indices]
+            pu = obj_events["DirectObjects"]["BTagging_AntiKt4EMPFlowAuxDyn.DL1dv01_pu"][indices]
+            # DL1d score: log(pb / (fc*pc + (1-fc)*pu)), fc=0.018 is standard ATLAS.
+            fc = 0.018
+            dl1d = np.log(pb / (fc * pc + (1 - fc) * pu))
+            mask = dl1d > 0
+            print(dl1d[mask])
+            is_bjet = dl1d > 2.51
+        else:
+            return obj_events
+        obj_events["BJets"] = obj_events["Jets"][is_bjet]
+        obj_events["Jets"] = obj_events["Jets"][~is_bjet]        
     
     @staticmethod
     def _get_data_tree_name(
@@ -175,6 +183,7 @@ class FileParser:
         
         obj_branches = {}
         objects = schema_config["objects"]
+        direct_objects = schema_config.get("direct_objects", [])
         naming_pattern = schema_config.get("naming_pattern", "dotted")
         
         for obj_name, fields in objects.items():
@@ -189,7 +198,8 @@ class FileParser:
             
             if obj_branches_for_obj:
                 obj_branches[obj_name] = obj_branches_for_obj
-        
+        # Keep direct object names as-is, but store them under the "DirectObjects" key.
+        obj_branches.update({"DirectObjects": {k: k for k in direct_objects}})
         return obj_branches
     
     @staticmethod
@@ -407,7 +417,7 @@ class FileParser:
             }
             if accessible_branches and FileParser._can_calculate_inv_mass(
                 list(accessible_branches.values())
-            ):
+            ) or obj_name == "DirectObjects":
                 accessible_obj_branches[obj_name] = accessible_branches
         
         return accessible_obj_branches

--- a/services/parsing/file_parser.py
+++ b/services/parsing/file_parser.py
@@ -108,8 +108,7 @@ class FileParser:
     @staticmethod
     def _calculate_btagging_and_split(
         obj_events: dict[str, ak.Array],
-
-    ):
+    ) -> dict[str, ak.Array]:
         """
         For each Jet objects in each event, calculates the b-tagging discriminant.
         Then, decides if each jet is a bjet or not. If bjet, stores in obj_events["BJet"] and removes from obj_events["Jets"]
@@ -130,12 +129,12 @@ class FileParser:
             fc = 0.018
             dl1d = np.log(pb / (fc * pc + (1 - fc) * pu))
             mask = dl1d > 0
-            print(dl1d[mask])
             is_bjet = dl1d > 2.51
         else:
             return obj_events
         obj_events["BJets"] = obj_events["Jets"][is_bjet]
-        obj_events["Jets"] = obj_events["Jets"][~is_bjet]        
+        obj_events["Jets"] = obj_events["Jets"][~is_bjet]
+        return obj_events
     
     @staticmethod
     def _get_data_tree_name(

--- a/services/parsing/schemas.py
+++ b/services/parsing/schemas.py
@@ -25,6 +25,19 @@ BASE_OBJECTS = {
     "Taus": ["pt", "eta", "phi", "mass"]
 }
 
+# Objects required for b-tagging in PHYSLITE files; they store the btagging
+# data in a separate container, linked to by the AnalysisJets objects.
+PHYSLITE_BTAGGING_OBJECTS = [
+    "AnalysisJetsAuxDyn.btaggingLink/AnalysisJetsAuxDyn.btaggingLink.m_persIndex",
+    "BTagging_AntiKt4EMPFlowAuxDyn.DL1dv01_pb",
+    "BTagging_AntiKt4EMPFlowAuxDyn.DL1dv01_pc",
+    "BTagging_AntiKt4EMPFlowAuxDyn.DL1dv01_pu"
+]
+
+NANOAOD_BTAGGING_OBJECTS = [
+    "Jet_btagDeepFlavB"
+]
+
 # Mapping from specific record IDs to their release year/schema identifier
 # This will be populated when schemas are extracted from record IDs
 RECORD_ID_TO_SCHEMA = {
@@ -41,6 +54,9 @@ RECORD_ID_TO_SCHEMA = {
 # - "branch_suffix": suffix after object name (empty string if none)
 # - "object_mappings": map from canonical object names to branch object names
 # - "objects": dict of canonical object names to required fields
+# - "direct_objects": Objects which are accessed *directly*, with no naming
+#    pattern / suffix / prefix. Intended for internal use only!
+
 RELEASE_SCHEMAS = {
     "2024r-pp": {
         "naming_pattern": "dotted",  # AnalysisElectronsAuxDyn.pt
@@ -53,7 +69,8 @@ RELEASE_SCHEMAS = {
             "Photons": "Photons",
             "Taus": "TauJets"
         },
-        "objects": BASE_OBJECTS.copy()
+        "objects": BASE_OBJECTS.copy(),
+        "direct_objects": PHYSLITE_BTAGGING_OBJECTS.copy()
     },
     "cms-nanoaod": {
         "naming_pattern": "flat",  # Electron_pt, Electron_eta, Muon_pt, etc.
@@ -69,10 +86,11 @@ RELEASE_SCHEMAS = {
         "objects": {
             "Electrons": ["pt", "eta", "phi", "mass"],
             "Muons": ["pt", "eta", "phi", "mass"],
-            "Jets": ["pt", "eta", "phi", "mass", "btagDeepFlavB"],
+            "Jets": ["pt", "eta", "phi", "mass"],
             "Photons": ["pt", "eta", "phi", "mass"],  # NanoAOD includes Photon_mass
             "Taus": ["pt", "eta", "phi", "mass", "charge", "decayMode", "idDeepTau2017v2p1VSjet"]
-        }
+        },
+        "direct_objects": NANOAOD_BTAGGING_OBJECTS.copy()
     },
     "2024r-hi": {
         "naming_pattern": "dotted",  # MuonsAuxDyn.pt

--- a/services/parsing/threaded_processor.py
+++ b/services/parsing/threaded_processor.py
@@ -49,8 +49,7 @@ class ThreadedFileProcessor:
         release_year: str,
         batch_size: int = 40_000,
         enable_jet_tagging: bool = False,
-        jet_btag_field: str = "btagDeepFlavB",
-        jet_btag_threshold: float = 0.5,
+        jet_btagging_thresholds: Optional[dict[str, float]] = None,
         on_success: Optional[Callable[[str, int, float], None]] = None,
         on_error: Optional[Callable[[str, Exception], None]] = None
     ) -> Iterator[EventBatch]:
@@ -80,8 +79,7 @@ class ThreadedFileProcessor:
                     release_year,
                     batch_size,
                     enable_jet_tagging,
-                    jet_btag_field,
-                    jet_btag_threshold,
+                    jet_btagging_thresholds,
                 ): file_url
                 for file_url in file_urls
             }
@@ -129,8 +127,7 @@ class ThreadedFileProcessor:
         release_year: str,
         batch_size: int,
         enable_jet_tagging: bool,
-        jet_btag_field: str,
-        jet_btag_threshold: float,
+        jet_btagging_thresholds: Optional[dict[str, float]],
     ) -> Optional[tuple]:
         """
         Parse a single file (runs in thread).
@@ -153,8 +150,7 @@ class ThreadedFileProcessor:
             release_year=release_year,
             batch_size=batch_size,
             enable_jet_tagging=enable_jet_tagging,
-            jet_btag_field=jet_btag_field,
-            jet_btag_threshold=jet_btag_threshold,
+            jet_btagging_thresholds=jet_btagging_thresholds,
         )
         
         processing_time = time.time() - start_time


### PR DESCRIPTION
This PR implements support for the PHYSLITE b-tagging objects, while keeping the existing NanoAOD support.
It supports different thresholds for different algorithms; see `jet_btagging_thresholds` in the sample `config.yaml` file.

In order to support the b-tagging containers documented [here](https://atlas-physlite-content-opendata.web.cern.ch/), spec. `BTagging_AntiKt4EMPFlow`, I had to add a rather awkward `DirectObjects` object in `schemas.py`, which allows for direct access to variables in ROOT. This artifact is later removed, and is not available to stages further on.