### PR TITLE
work on general setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -445,3 +445,12 @@ For final states with low statistics (e.g. 2μ+1j), the first empty bin
 occurs early in the high-mass tail, causing the postproc histogram to
 be truncated. Use `exclude_outliers: false` in histogram creation to
 include the full distribution above the Z peak cut.
+
+### Running single-files does not create `logs/global_ranges.json`
+
+Not a problem if you ran multi-jobs (`submit.sh` with `NUM_JOBS>1`). 
+Current workaround: After the job crashed due to this error, you can still finish it with 
+```
+python main.py --scan-only --run-dir <run_dir> # creates the json file
+python main.py --tasks histogram_creation --run-dir <run_dir> # resume where left off
+```

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -446,11 +446,18 @@ occurs early in the high-mass tail, causing the postproc histogram to
 be truncated. Use `exclude_outliers: false` in histogram creation to
 include the full distribution above the Z peak cut.
 
-### Running single-files does not create `logs/global_ranges.json`
+### Running single-call does not create `logs/global_ranges.json`
 
-Not a problem if you ran multi-jobs (`submit.sh` with `NUM_JOBS>1`). 
-Current workaround: After the job crashed due to this error, you can still finish it with 
+E.g. doing `python main.py` or `bash submit.sh`. But the setup works if run in stages. For a single job: 
+
 ```
-python main.py --scan-only --run-dir <run_dir> # creates the json file
-python main.py --tasks histogram_creation --run-dir <run_dir> # resume where left off
+# 1. Run everything except histogram creation
+python main.py --tasks parsing,mass_calculating,post_processing
+# prints run_dir e.g. ./output/atlas_full_fixComb_fixCut_<timestamp>
+
+# 2. Compute the global ranges
+python main.py --scan-only --run-dir <run_dir>
+
+# 3. Finish with histogram creation
+python main.py --tasks histogram_creation --run-dir <run_dir>
 ```

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -461,3 +461,7 @@ python main.py --scan-only --run-dir <run_dir>
 # 3. Finish with histogram creation
 python main.py --tasks histogram_creation --run-dir <run_dir>
 ```
+
+### $$\Delta R$$-based overlap removal missing
+
+E.g. `ROI_mass_g0t0_cat_0ex_0mx_4jx_1gx_1tx_0bx_width_10.0` strong peak in first bin, as photon and tau are the same. 

--- a/README.md
+++ b/README.md
@@ -195,3 +195,24 @@ python main.py --help
   --merge-only               Merge batch outputs (hadd + aggregate stats + plots)
   --plots-only               Re-generate plots from an existing run
 ```
+
+## Naming convension
+
+| letter | particle |
+|--------|----------|
+| e | Electrons |
+| m | Muons |
+| j | Jets |
+| b | b-jets |
+| g | Photons |
+| t | Taus |
+
+The output histograms read as: 
+
+`ROI_mass_j0j1t0_cat_0ex_0mx_4jx_0gx_1tx_0bx_width_10.0`
+
+- `ROI`: region of interest
+- `mass_j0j1t0`: invariant mass of the two leading jets and the leading $\tau$
+- `cat`: category - which objects are present in this event
+- `0ex`: zero electrons etc.
+- `width_10.0`: bin width (GeV)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
 lsetup "views LCG_106a_ATLAS_1 x86_64-el9-gcc14-opt"
 ```
 
+Make sure python (check with `which python`) points you to `cvmfs`. You then still need to install some dependencies: 
+
+```
+pip install --user -r docker/requirements.txt
+```
+
 ## Usage
 
 Everything is controlled through one file: **`config.yaml`**.

--- a/config.yaml
+++ b/config.yaml
@@ -88,7 +88,7 @@ parsing_task_config:
   count_retries_failed_files: 3
   fetching_metadata_timeout: 60
   max_files_to_process: null             # null = all files; set e.g. 3 for a quick test
-  enable_jet_tagging: false              # when true, split Jets into BJets/LJets. Must give thresholds for btagging discriminants!
+  enable_jet_tagging: false              # when true, split Jets into BJets/Jets. Must give thresholds for btagging discriminants!
   jet_btagging_thresholds:
     btagDeepFlavB: 0.5
     DL1d: 2.51

--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,7 @@ names:
 # ===RUN METADATA=============================================================
 run_metadata:
   run_name: *run_name
-  base_output_dir: "/data"
+  base_output_dir: "./output"
   batch_job_index: null                  # set by submit.sh (--batch-job-index)
   total_batch_jobs: null                 # set by submit.sh (--total-batch-jobs)
 
@@ -123,7 +123,7 @@ parsing_task_config:
 # Computes invariant masses for every valid particle combination per final state.
 mass_calculation_task_config:
   # ===PATHS===
-  input_dir:  "/data/atlas_pp_root_files"
+  input_dir:  *parsed_data_path
   output_dir: *im_arrays_path
 
   # ===PROCESSING===

--- a/orchestration/handlers/mass_calculation_handler.py
+++ b/orchestration/handlers/mass_calculation_handler.py
@@ -101,9 +101,13 @@ class MassCalculationHandler(StateHandler):
                     f"processing files {slice_start+1}-{slice_end} of {total_files}"
                 )
 
-        if not root_files:
+        if not root_files: # handle case of no files to process
             self.logger.warning(f"No parsed ROOT files found in {parsed_dir}")
-            return context, self._determine_next_state(context)
+            sqlite_writer.close() # create empty shard file
+            updated = context.with_im_files([shard_name])
+            next_state = self._determine_next_state(updated)
+            self._log_state_exit(context, next_state)
+            return updated, next_state
 
         total_created_chunks = 0
 

--- a/orchestration/handlers/parsing_handler.py
+++ b/orchestration/handlers/parsing_handler.py
@@ -110,7 +110,6 @@ class ParsingHandler(StateHandler):
         stats_collector = ParsingStatisticsCollector()
         parsed_files = []
         
-        # ---- Apply batch splitting if configured ----
         metadata = dict(context.metadata)  # mutable copy
         # Filter to only requested release years (supports _mc suffix convention)
         if parsing_config.release_years:
@@ -120,15 +119,22 @@ class ParsingHandler(StateHandler):
                 f"Filtered metadata to release_years={parsing_config.release_years}: "
                 f"{list(metadata.keys())}"
             )
+        # ---- Drop MC keys if configured ----
+        if not parsing_config.parse_mc:
+            for year in [y for y in metadata if y.endswith("_mc")]:
+                self.logger.info(f"Skipping MC key '{year}' (parse_mc=False)")
+                del metadata[year]
+
+        # ---- Apply batch splitting if configured ----
         batch_idx = context.config.batch_job_index
         total_batches = context.config.total_batch_jobs
-        
+
         if batch_idx is not None and total_batches is not None:
             self.logger.info(
                 f"Batch mode: job {batch_idx}/{total_batches}"
             )
             metadata = get_batch_slice_by_year(metadata, batch_idx, total_batches)
-        
+
         # ---- Apply max_files_to_process limit (per year) ----
         max_files = getattr(parsing_config, 'max_files_to_process', None)
         if max_files and max_files > 0:
@@ -140,17 +146,9 @@ class ParsingHandler(StateHandler):
                         f"Limiting {year} to {max_files} files "
                         f"(was {original}, max_files_to_process={max_files})"
                     )
-        
+
         # Parse each release year
         for release_year, file_urls in metadata.items():
-            # ── Skip MC keys when parse_mc=False ─────────────────────────────────────
-            # The fetcher always separates data and MC into separate keys (e.g.
-            # '2024r-pp' and '2024r-pp_mc'). parse_mc controls whether MC is
-            # included in the parsing run, not whether it is separated.
-            if release_year.endswith("_mc") and not parsing_config.parse_mc:
-                self.logger.info(f"Skipping MC key '{release_year}' (parse_mc=False)")
-                continue
-
             self.logger.info(
                 f"Parsing {len(file_urls)} files for release year: {release_year}"
             )

--- a/services/calculations/im_calculator.py
+++ b/services/calculations/im_calculator.py
@@ -14,6 +14,8 @@ from services.calculations.combinatorics import get_count, get_start
 
 
 class IMCalculator:
+    _INVALID_FS_LABEL = "" # sentinal value for invalid final states
+
     def __init__(self, events: ak.Array, min_events_per_fs: int,
                  min_k: int, max_k: int, min_n: int, max_n: int):
         self.events = events
@@ -70,10 +72,11 @@ class IMCalculator:
             t = ak.to_numpy(getattr(particle_counts, "Taus", zero_array))
             b = ak.to_numpy(getattr(particle_counts, "BJets", zero_array))
 
+            # one label per event ("" for invalid final states) 
             all_events_fs = [
                 f"{e}e_{m}m_{j}j_{g}g_{t}t_{b}b"
+                if self._is_valid_fs([e, m, j, g, t, b]) else self._INVALID_FS_LABEL
                 for e, m, j, g, t, b in zip(e, m, j, g, t, b)
-                if self._is_valid_fs([e, m, j, g, t, b])
             ]
             self._all_events_fs = ak.Array(all_events_fs)
         return self._all_events_fs
@@ -92,6 +95,7 @@ class IMCalculator:
         all_events_fs_list = ak.to_list(all_events_fs)
 
         fs_by_count = Counter(all_events_fs_list)
+        fs_by_count.pop(self._INVALID_FS_LABEL, None) # remove invalid final states from the count
         fs_by_count_sorted = [
             (fs, count) for fs, count in fs_by_count.most_common()
             if count >= self.min_events_per_fs


### PR DESCRIPTION
Fixes: 
- README.md: Option B — ATLAS cluster (CVMFS / LCG) does not work without installing further dependencies. Add description on how to install the requirements
- config.yaml: hard-coded paths for some output. Change to `./output` or dynamic variable used in process. 
- CHANGES.md: mention bug due to missing creation of `global_ranges.json`
- Remove leftover "Ljet" code, see [this commit](https://github.com/Zhavi221/atlas-utilization/commit/b1d81cc6ce98a9040ee4d029a8f90c20c829aa62)
- fix serious bug: masking in `services/calculations/im_calculator.py` went wrong until now.  
- handle case when no root input files are parsed (return empty shard file instead of error)
- remove `_mc` files (if configured) BEFORE batch splitting is applied.