### PR TITLE
Refactor: Move scan-only into the histogram creations stage

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,10 +112,6 @@ def parse_args():
     # --- Post-run options ---
     post_group = parser.add_argument_group("Post-Run Options")
     post_group.add_argument(
-        "--scan-only", action="store_true",
-        help="Pre-scan processed arrays to compute global histogram ranges"
-    )
-    post_group.add_argument(
         "--merge-only", action="store_true",
         help="Merge batch outputs: hadd histograms + aggregate stats + generate plots"
     )
@@ -127,8 +123,6 @@ def parse_args():
     args = parser.parse_args()
 
     # Validation
-    if args.scan_only and args.run_dir is None:
-        parser.error("--run-dir is required when --scan-only is set")
     if args.batch_job_index is not None and args.total_batch_jobs is None:
         parser.error("--total-batch-jobs is required when --batch-job-index is set")
     if args.total_batch_jobs is not None and args.batch_job_index is None:
@@ -137,10 +131,6 @@ def parse_args():
         parser.error("--run-dir is required when --plots-only or --merge-only is set")
     if args.plots_only and args.merge_only:
         parser.error("--plots-only and --merge-only are mutually exclusive")
-    if args.scan_only and args.merge_only:
-        parser.error("--scan-only and --merge-only are mutually exclusive")
-    if args.scan_only and args.plots_only:
-        parser.error("--scan-only and --plots-only are mutually exclusive")
 
     return args
 
@@ -184,19 +174,6 @@ def main():
             logger.info("✓ Merge completed successfully")
             return 0
 
-        # ------------------------------------------------------------------
-        # SCAN-ONLY MODE: compute global histogram ranges
-        # ------------------------------------------------------------------
-        if args.scan_only:
-            logger.info(f"Scan-only mode: computing global ranges from {args.run_dir}")
-            config_dict = load_config(args.config)
-            config_dict = update_config_paths_with_run_dir(config_dict, args.run_dir)
-            config = PipelineConfig.from_dict(config_dict)
-            executor = PipelineExecutor(config)
-            executor.scan_global_ranges(args.run_dir)
-            logger.info("✓ Global ranges computed successfully")
-            return 0
-        
         # ------------------------------------------------------------------
         # NORMAL / BATCH PIPELINE MODE
         # ------------------------------------------------------------------

--- a/orchestration/handlers/histogram_creation_handler.py
+++ b/orchestration/handlers/histogram_creation_handler.py
@@ -80,6 +80,9 @@ class HistogramCreationHandler(StateHandler):
         global_ranges_path = getattr(hc, 'global_ranges_path', None)
         if not global_ranges_path:
             return
+        # Safe to skip the lock here only because save_global_ranges() publishes
+        # the file with an atomic rename — the path either does not exist or is
+        # complete, never half-written.
         if os.path.exists(global_ranges_path):
             self.logger.info(f"Using existing global ranges: {global_ranges_path}")
             return

--- a/orchestration/handlers/histogram_creation_handler.py
+++ b/orchestration/handlers/histogram_creation_handler.py
@@ -4,6 +4,8 @@ HistogramCreationHandler - Handles histogram creation state.
 Delegates to the histograms_pipeline module.
 """
 
+import fcntl
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -29,6 +31,11 @@ class HistogramCreationHandler(StateHandler):
             return context, self._determine_next_state(context)
 
         start = datetime.now()
+
+        # Global bin edges must exist before any histogram is filled, so the
+        # scan runs first — otherwise concurrent batch jobs would each pick
+        # their own local min/max and `hadd` would fail to merge them.
+        self._ensure_global_ranges(hc)
 
         config_dict = {
             "input_dir": hc.input_dir,
@@ -63,3 +70,54 @@ class HistogramCreationHandler(StateHandler):
         next_state = self._determine_next_state(context)
         self._log_state_exit(context, next_state)
         return context, next_state
+
+    def _ensure_global_ranges(self, hc) -> None:
+        """
+        Compute global min/max per bumpnet signature across ALL processed
+        SQLite shards and save to ``hc.global_ranges_path``, unless it has
+        already been computed (e.g. by a concurrent histogram batch job).
+        """
+        global_ranges_path = getattr(hc, 'global_ranges_path', None)
+        if not global_ranges_path:
+            return
+        if os.path.exists(global_ranges_path):
+            self.logger.info(f"Using existing global ranges: {global_ranges_path}")
+            return
+
+        proc_dir = hc.input_dir
+        if not os.path.isdir(proc_dir):
+            self.logger.error(f"Cannot compute global ranges — input dir not found: {proc_dir}")
+            raise RuntimeError(f"Cannot compute global ranges — input dir not found: {proc_dir}")
+
+        sqlite_files = sorted(f for f in os.listdir(proc_dir) if f.endswith(".sqlite"))
+        if not sqlite_files:
+            self.logger.error(f"No processed SQLite files found in {proc_dir}")
+            raise RuntimeError(f"No processed SQLite files found in {proc_dir}")
+
+        ranges_dir = os.path.dirname(global_ranges_path)
+        os.makedirs(ranges_dir, exist_ok=True)
+        lock_path = global_ranges_path + ".lock"
+
+        from services.pipelines.histograms_pipeline import compute_global_ranges, save_global_ranges
+
+        with open(lock_path, "w") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                if os.path.exists(global_ranges_path):
+                    self.logger.info(
+                        f"Global ranges already computed by a concurrent job: {global_ranges_path}"
+                    )
+                    return
+
+                self.logger.info(
+                    f"Scanning {len(sqlite_files)} SQLite files for global ranges..."
+                )
+                ranges = compute_global_ranges(
+                    sqlite_files, proc_dir, exclude_outliers=hc.exclude_outliers
+                )
+                save_global_ranges(ranges, global_ranges_path)
+                self.logger.info(
+                    f"Saved global ranges for {len(ranges)} signatures to {global_ranges_path}"
+                )
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/pipeline/executor.py
+++ b/pipeline/executor.py
@@ -7,10 +7,13 @@ Supports consolidated plot generation from output data.
 Architecture (multi-job mode):
   Each batch job runs parsing + mass_calc + post_processing and saves:
     - batch_N_stats.json   → logs/
-  The scan job (--scan-only) runs after all batch jobs and saves:
-    - global_ranges.json   → logs/
-  The histogram array jobs run after scan and save:
+  The histogram array jobs run after all batch jobs and save:
     - batch_N.root         → histograms/
+  The first histogram job to reach HISTOGRAM_CREATION computes the global
+  bin-edge ranges as its first step and saves them to:
+    - global_ranges.json   → histograms/
+  (see HistogramCreationHandler._ensure_global_ranges) so that later
+  histogram jobs reuse the same edges and `hadd` merges correctly.
   The merge job (--merge-only) combines everything via:
     - hadd histograms/batch_*.root → histograms/<output_filename>
     - JSON stats aggregation
@@ -133,38 +136,6 @@ class PipelineExecutor:
         self.logger.info(f"Saved batch stats to: {stats_path}")
 
 
-    def scan_global_ranges(self, run_dir: str):
-        """
-        Pre-scan all processed SQLite files to compute global min/max per
-        bumpnet signature. Saves result to logs/global_ranges.json.
-        Must run before histogram creation batches.
-        """
-        from services.pipelines.histograms_pipeline import compute_global_ranges, save_global_ranges
-
-        proc_dir = os.path.join(run_dir, "im_arrays_processed")
-        logs_dir = os.path.join(run_dir, "logs")
-        os.makedirs(logs_dir, exist_ok=True)
-
-        sqlite_files = sorted([
-            f for f in os.listdir(proc_dir) if f.endswith(".sqlite")
-        ])
-        if not sqlite_files:
-            self.logger.error(f"No processed SQLite files found in {proc_dir}")
-            raise RuntimeError(f"No processed SQLite files found in {proc_dir}")
-
-        self.logger.info(f"Scanning {len(sqlite_files)} SQLite files for global ranges...")
-
-        hc = self.config.histogram_creation_config
-        exclude_outliers = hc.exclude_outliers if hc else True
-
-        ranges = compute_global_ranges(sqlite_files, proc_dir, exclude_outliers=exclude_outliers)
-
-        output_path = os.path.join(logs_dir, "global_ranges.json")
-        save_global_ranges(ranges, output_path)
-        self.logger.info(
-            f"Saved global ranges for {len(ranges)} signatures to {output_path}"
-        )
-
     def merge_outputs(self, run_dir: str):
         """
         Merge outputs from all batch jobs:
@@ -237,9 +208,7 @@ class PipelineExecutor:
                     "output_filename": hc.pre_postproc_filename,
                     "exclude_outliers": False,
                     "use_bumpnet_naming": hc.use_bumpnet_naming,
-                    "global_ranges_path": os.path.join(
-                        run_dir, "logs", "global_ranges.json"
-                    ),
+                    "global_ranges_path": os.path.join(hist_dir, "global_ranges.json"),
                 }
                 create_histograms(nopp_config, file_list=im_sqlite_files)
                 self.logger.info(

--- a/services/pipelines/histograms_pipeline.py
+++ b/services/pipelines/histograms_pipeline.py
@@ -19,9 +19,23 @@ from services.storage.sqlite_shards import list_signatures, iter_arrays_for_sign
 
 
 def save_global_ranges(ranges: Dict, output_path: str):
+    """
+    Write the ranges atomically: concurrent histogram batch jobs test for the
+    existence of this file to decide whether to skip the scan, so it must never
+    be observable in a partially-written state.
+    """
     import json
-    with open(output_path, "w") as f:
-        json.dump(ranges, f, indent=2)
+    tmp_path = f"{output_path}.tmp.{os.getpid()}"
+    try:
+        with open(tmp_path, "w") as f:
+            json.dump(ranges, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, output_path)
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
     logging.getLogger(__name__).info(f"Saved global ranges to {output_path}")
 
 def load_global_ranges(path: str) -> Dict[str, Tuple[float, float]]:

--- a/services/pipelines/histograms_pipeline.py
+++ b/services/pipelines/histograms_pipeline.py
@@ -360,7 +360,8 @@ def _create_merged_histograms_from_sqlite_signatures(
         if hist_name_base not in global_ranges:
             logger.warning(
                 f"{hist_name_base} not found in global_ranges — skipping. "
-                "Re-run scan-only job to regenerate global_ranges.json."
+                "Delete histograms/global_ranges.json and re-run histogram "
+                "creation to regenerate it."
             )
             return []
         global_min, global_max = global_ranges[hist_name_base]

--- a/submit_data.sh
+++ b/submit_data.sh
@@ -4,7 +4,7 @@
 #
 # Job chain:
 #   batch array (parsing+mass_calculating) → postproc (single job) →
-#   scan → histogram array → merge
+#   histogram array → merge
 # ===========================================================================
 
 set -e
@@ -15,7 +15,6 @@ CPUS_PER_JOB=4
 MEM_PER_JOB="180gb"
 WALLTIME="12:00:00"
 POSTPROC_WALLTIME="24:00:00"
-SCAN_WALLTIME="04:00:00"
 HIST_WALLTIME="24:00:00"
 MERGE_WALLTIME="08:00:00"
 QUEUE="N"
@@ -104,37 +103,12 @@ EOF
 )
 echo "Submitted postproc: ${POSTPROC_JOB_ID} (depends on all batches)"
 
-# Stage 3: scan global ranges — depends on postproc
-SCAN_JOB_ID=$(qsub -W depend=afterok:"${POSTPROC_JOB_ID}" <<EOF
-#!/bin/bash
-#PBS -q ${QUEUE}
-#PBS -N atlas_data_scan
-#PBS -o ${LOG_DIR}/
-#PBS -e ${LOG_DIR}/
-#PBS -l select=1:ncpus=2:mem=64gb
-#PBS -l io=5
-#PBS -l walltime=${SCAN_WALLTIME}
-
-cd ${PIPELINE_DIR}
-
-export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
-source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
-lsetup "views LCG_107 x86_64-el9-gcc14-opt"
-source ${PIPELINE_DIR}/atlasenv/bin/activate
-
-python -u main.py --config "${CONFIG}" \
-    --scan-only \
-    --run-dir "${RUN_DIR}" \
-    > "${LOG_DIR}/scan.out" \
-    2> "${LOG_DIR}/scan.err"
-EOF
-)
-echo "Submitted scan: ${SCAN_JOB_ID} (depends on postproc)"
-
-# Stage 4: histogram creation — per batch, depends on scan
+# Stage 3: histogram creation — per batch, depends on postproc.
+# The first batch job to reach HISTOGRAM_CREATION computes global_ranges.json
+# (file-locked), the rest reuse it.
 HIST_JOB_IDS=""
 for i in $(seq 1 $NUM_JOBS); do
-    JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
+    JOB_ID=$(qsub -W depend=afterok:"${POSTPROC_JOB_ID}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
 #PBS -N atlas_data_hist_${i}
@@ -165,7 +139,7 @@ EOF
 done
 echo "All hist jobs: ${HIST_JOB_IDS}"
 
-# Stage 5: merge — depends on ALL histogram jobs
+# Stage 4: merge — depends on ALL histogram jobs
 MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_IDS}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
@@ -196,7 +170,6 @@ echo ""
 echo "Job chain:"
 echo "  Batches:    ${BATCH_JOB_IDS}"
 echo "  Postproc:   ${POSTPROC_JOB_ID}"
-echo "  Scan:       ${SCAN_JOB_ID}"
 echo "  Histograms: ${HIST_JOB_IDS}"
 echo "  Merge:      ${MERGE_JOB_ID}"
 echo ""

--- a/submit_mc.sh
+++ b/submit_mc.sh
@@ -4,7 +4,7 @@
 #
 # Job chain:
 #   batch array (parsing+mass_calculating) → postproc (single job) →
-#   scan → histogram array → merge
+#   histogram array → merge
 # ===========================================================================
 
 set -e
@@ -15,7 +15,6 @@ CPUS_PER_JOB=4
 MEM_PER_JOB="180gb"
 WALLTIME="12:00:00"
 POSTPROC_WALLTIME="24:00:00"
-SCAN_WALLTIME="04:00:00"
 HIST_WALLTIME="24:00:00"
 MERGE_WALLTIME="04:00:00"
 QUEUE="N"
@@ -104,37 +103,12 @@ EOF
 )
 echo "Submitted postproc: ${POSTPROC_JOB_ID} (depends on all batches)"
 
-# Stage 3: scan global ranges — depends on postproc
-SCAN_JOB_ID=$(qsub -W depend=afterok:"${POSTPROC_JOB_ID}" <<EOF
-#!/bin/bash
-#PBS -q ${QUEUE}
-#PBS -N atlas_mc_scan
-#PBS -o ${LOG_DIR}/
-#PBS -e ${LOG_DIR}/
-#PBS -l select=1:ncpus=2:mem=64gb
-#PBS -l io=5
-#PBS -l walltime=${SCAN_WALLTIME}
-
-cd ${PIPELINE_DIR}
-
-export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
-source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
-lsetup "views LCG_107 x86_64-el9-gcc14-opt"
-source ${PIPELINE_DIR}/atlasenv/bin/activate
-
-python -u main.py --config "${CONFIG}" \
-    --scan-only \
-    --run-dir "${RUN_DIR}" \
-    > "${LOG_DIR}/scan.out" \
-    2> "${LOG_DIR}/scan.err"
-EOF
-)
-echo "Submitted scan: ${SCAN_JOB_ID} (depends on postproc)"
-
-# Stage 4: histogram creation — per batch, depends on scan
+# Stage 3: histogram creation — per batch, depends on postproc.
+# The first batch job to reach HISTOGRAM_CREATION computes global_ranges.json
+# (file-locked), the rest reuse it.
 HIST_JOB_IDS=""
 for i in $(seq 1 $NUM_JOBS); do
-    JOB_ID=$(qsub -W depend=afterok:"${SCAN_JOB_ID}" <<EOF
+    JOB_ID=$(qsub -W depend=afterok:"${POSTPROC_JOB_ID}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
 #PBS -N atlas_mc_hist_${i}
@@ -165,7 +139,7 @@ EOF
 done
 echo "All hist jobs: ${HIST_JOB_IDS}"
 
-# Stage 5: merge — depends on ALL histogram jobs
+# Stage 4: merge — depends on ALL histogram jobs
 MERGE_JOB_ID=$(qsub -W depend=afterok:"${HIST_JOB_IDS}" <<EOF
 #!/bin/bash
 #PBS -q ${QUEUE}
@@ -196,7 +170,6 @@ echo ""
 echo "Job chain:"
 echo "  Batches:    ${BATCH_JOB_IDS}"
 echo "  Postproc:   ${POSTPROC_JOB_ID}"
-echo "  Scan:       ${SCAN_JOB_ID}"
 echo "  Histograms: ${HIST_JOB_IDS}"
 echo "  Merge:      ${MERGE_JOB_ID}"
 echo ""

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -95,8 +95,9 @@ def update_config_paths_with_run_dir(config_dict: dict, run_dir: str) -> dict:
         hist_config = updated_config['histogram_creation_task_config']
         _set_if_relative(hist_config, 'input_dir', os.path.join(run_dir, "im_arrays_processed"))
         _set_if_relative(hist_config, 'output_dir', os.path.join(run_dir, "histograms"))
-        # Always set global_ranges_path — scan job writes here, histogram batches read from here
-        hist_config['global_ranges_path'] = os.path.join(run_dir, "logs", "global_ranges.json")
+        # Always set global_ranges_path — it's an artifact of histogram creation
+        # (computed on first use, reused by later batch jobs)
+        hist_config['global_ranges_path'] = os.path.join(hist_config['output_dir'], "global_ranges.json")
 
     return updated_config
 


### PR DESCRIPTION
Currently, we require to run all stages until histogram creation, then run `--scan-only`, then run histogram creation.
This PR moves scan-only logic to the beginning of the histogram creation state, and updates setup_mc.sh and setup_data.sh accordingly. It also moves the global ranges file to the histogram directory rather than the log directory.
I verified this code on a small sample of files, and it produces the same results. However, I didn't verify it on a cluster job yet.

It may conflict with #7, which assumes scan-only exists.

Tagging @maryna-git for code review :)