### PR TITLE
Bugfix: Incorrect particle type counting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -108,7 +108,6 @@ parsing_task_config:
     muons:     { min: 0, max: 4 }
     jets:      { min: 0, max: 4 }
     bjets:     { min: 0, max: 4 }
-    ljets:     { min: 0, max: 4 }
     photons:   { min: 0, max: 4 }
     taus:      { min: 0, max: 4 }
 
@@ -117,7 +116,6 @@ parsing_task_config:
     muons:     { pt_min: 25000.0, eta_max: 2.5 }
     jets:      { pt_min: 30000.0, eta_max: 4.5 }
     bjets:     { pt_min: 30000.0, eta_max: 4.5 }
-    ljets:     { pt_min: 30000.0, eta_max: 4.5 }
     photons:   { pt_min: 25000.0, eta_max: 2.37 }
     taus:      { pt_min: 20000.0, eta_max: 2.5 }
 
@@ -135,7 +133,7 @@ mass_calculation_task_config:
   fs_chunk_threshold_bytes: 2000000000  # 2 GB
 
   # ===COMBINATORICS===
-  objects_to_calculate: [Electrons, Muons, Jets, BJets, LJets, Photons, Taus]
+  objects_to_calculate: [Electrons, Muons, Jets, BJets, Photons, Taus]
   min_particles_in_combination: 2        # min particle types in a combination
   max_particles_in_combination: 4        # max particle types was 4 reduces 12,567 → ~28 combinations
   min_count_particle_in_combination: 1   # min count per type

--- a/domain/config.py
+++ b/domain/config.py
@@ -101,7 +101,7 @@ class MassCalculationConfig:
     
     # Combinatorics configuration
     objects_to_calculate: tuple[str, ...] = (
-        "Electrons", "Muons", "Jets", "BJets", "LJets", "Photons", "Taus"
+        "Electrons", "Muons", "Jets", "BJets", "Photons", "Taus"
     )
     min_particles_in_combination: int = 2
     max_particles_in_combination: int = 4
@@ -311,7 +311,7 @@ class PipelineConfig:
             # Handle objects_to_calculate (can be None or list)
             objects_raw = mass_dict.get("objects_to_calculate")
             objects = tuple(objects_raw) if objects_raw else (
-                "Electrons", "Muons", "Jets", "BJets", "LJets", "Photons", "Taus"
+                "Electrons", "Muons", "Jets", "BJets", "Photons", "Taus"
             )
             
             mass_calculation_config = MassCalculationConfig(

--- a/pipeline/executor.py
+++ b/pipeline/executor.py
@@ -490,7 +490,7 @@ class PipelineExecutor:
             particle_pattern = re.compile(r'(\d+)([emjgtbl])')
             particle_name_map = {
                 'e': 'Electrons', 'm': 'Muons', 'j': 'Jets', 'g': 'Photons',
-                't': 'Taus', 'b': 'BJets', 'l': 'LJets'
+                't': 'Taus', 'b': 'BJets'
             }
 
             for sf in sqlite_files:
@@ -558,7 +558,7 @@ class PipelineExecutor:
         particle_pattern = re.compile(r'(\d+)([emjgtbl])')
         particle_name_map = {
             'e': 'Electrons', 'm': 'Muons', 'j': 'Jets', 'g': 'Photons',
-            't': 'Taus', 'b': 'BJets', 'l': 'LJets'
+            't': 'Taus', 'b': 'BJets'
         }
 
         for nf in npy_files:

--- a/pipeline/executor.py
+++ b/pipeline/executor.py
@@ -459,10 +459,13 @@ class PipelineExecutor:
     def _read_im_array_stats(self, im_dir: str):
         """Read invariant mass array (.npy) files and compute stats.
 
-        Filenames follow the pattern:
-            <prefix>_FS_<Xe>_<Xm>_<Xj>_<Xg>_IM_<Ye>_<Ym>_<Yj>_<Yg>.npy
+        Names follow the pattern built by prepare_im_combination_name():
+            <prefix>_FS_<Xe>_<Xm>_<Xj>_<Xg>_<Xt>_<Xb>_IM_<letter><rank>...
+        The FS part is count-first (2e = two electrons); the IM part lists one
+        entry per particle as letter + rank index (e0e1j0 = the two leading
+        electrons plus the leading jet).
         Example:
-            parsed_2024r-pp_batch2_final_FS_2e_2m_4j_2g_IM_2e_2m_4j_2g.npy
+            parsed_2024r-pp_batch2_final_FS_2e_0m_4j_0g_0t_0b_IM_e0e1j0.npy
         """
         import re
         import numpy as np
@@ -487,7 +490,7 @@ class PipelineExecutor:
             fs_im_pattern = re.compile(
                 r'_FS_([0-9a-z_]+)_IM_([0-9a-z_]+)$'
             )
-            particle_pattern = re.compile(r'(\d+)([emjgtbl])')
+            particle_pattern = re.compile(r'([emjgtb])(\d+)')
             particle_name_map = {
                 'e': 'Electrons', 'm': 'Muons', 'j': 'Jets', 'g': 'Photons',
                 't': 'Taus', 'b': 'BJets'
@@ -522,15 +525,20 @@ class PipelineExecutor:
 
                     if channel not in unique_channels:
                         unique_channels.add(channel)
+                        # IM part carries one entry per particle as letter+rank
+                        # ("e0e1j0" = 2 electrons + 1 jet), so distinct letters
+                        # give the number of particle types involved.
                         im_particles = particle_pattern.findall(im_str)
-                        involved_types = 0
-                        for count_str, pchar in im_particles:
-                            count = int(count_str)
-                            if count > 0:
-                                involved_types += 1
-                                pname = particle_name_map.get(pchar, pchar)
+                        if not im_particles:
+                            self.logger.debug(f"Could not parse IM part: {signature}")
+                            continue
+                        involved_types = set()
+                        for pchar, _rank in im_particles:
+                            pname = particle_name_map.get(pchar, pchar)
+                            if pname not in involved_types:
+                                involved_types.add(pname)
                                 combos_per_object[pname] = combos_per_object.get(pname, 0) + 1
-                        combo_sizes[involved_types] = combo_sizes.get(involved_types, 0) + 1
+                        combo_sizes[len(involved_types)] = combo_sizes.get(len(involved_types), 0) + 1
 
             return {
                 'total_final_states': len(unique_fs),
@@ -555,7 +563,7 @@ class PipelineExecutor:
         fs_im_pattern = re.compile(
             r'_FS_([0-9a-z_]+)_IM_([0-9a-z_]+)'
         )
-        particle_pattern = re.compile(r'(\d+)([emjgtbl])')
+        particle_pattern = re.compile(r'([emjgtb])(\d+)')
         particle_name_map = {
             'e': 'Electrons', 'm': 'Muons', 'j': 'Jets', 'g': 'Photons',
             't': 'Taus', 'b': 'BJets'
@@ -582,17 +590,22 @@ class PipelineExecutor:
                 if channel not in unique_channels:
                     unique_channels.add(channel)
                     # --- Per-object participation in unique channels ---
+                    # IM part carries one entry per particle as letter+rank
+                    # ("e0e1j0" = 2 electrons + 1 jet), so distinct letters
+                    # give the number of particle types involved.
                     im_particles = particle_pattern.findall(im_str)
-                    involved_types = 0
-                    for count_str, pchar in im_particles:
-                        count = int(count_str)
-                        if count > 0:
-                            involved_types += 1
-                            pname = particle_name_map.get(pchar, pchar)
+                    if not im_particles:
+                        self.logger.debug(f"Could not parse IM part: {nf.name}")
+                        continue
+                    involved_types = set()
+                    for pchar, _rank in im_particles:
+                        pname = particle_name_map.get(pchar, pchar)
+                        if pname not in involved_types:
+                            involved_types.add(pname)
                             combos_per_object[pname] = combos_per_object.get(pname, 0) + 1
 
                     # --- Channel size (number of particle types involved) ---
-                    combo_sizes[involved_types] = combo_sizes.get(involved_types, 0) + 1
+                    combo_sizes[len(involved_types)] = combo_sizes.get(len(involved_types), 0) + 1
 
             except Exception as e:
                 self.logger.warning(f"Could not read {nf}: {e}")

--- a/services/analysis/statistics_plotter.py
+++ b/services/analysis/statistics_plotter.py
@@ -474,7 +474,10 @@ class StatisticsPlotter:
         if combo_sizes:
             sizes = sorted(combo_sizes.keys())
             counts = [combo_sizes[s] for s in sizes]
-            bars = ax4.bar([f'{s}-body' for s in sizes], counts,
+            # Size is the number of particle *types* in the channel, not the
+            # particle count — e0e1j0 is 2 types (3 particles).
+            bars = ax4.bar([f'{s} type' if s == 1 else f'{s} types' for s in sizes],
+                          counts,
                           color=self.COLORS['accent'], edgecolor='white', linewidth=1.5)
             for bar, v in zip(bars, counts):
                 ax4.text(bar.get_x() + bar.get_width() / 2, bar.get_height(),

--- a/services/parsing/event_selection.py
+++ b/services/parsing/event_selection.py
@@ -18,7 +18,6 @@ YAML_PARTICLE_KEYS: Dict[str, str] = {
     "muons": "Muons",
     "jets": "Jets",
     "bjets": "BJets",
-    "ljets": "LJets",
     "photons": "Photons",
     "taus": "Taus",
 }


### PR DESCRIPTION
We noticed there are many 0-body / 1-body combinations. This doesn't make any physical sense, and arises from two bugs:
1. The naming convention `_read_im_array_stats` expected was wrong (was changed in commit `fda5837`). This affected only statistics generation.
2. LJets were still present in `objects_to_calculate`, after removing them from `PARTICLE_ORDER`, which caused combinations which differed only in LJet count to collide due to the logic in `prepare_im_combination_name`. 

This PR completely removes LJets, fixes the regex in `_read_im_array_stats`, and renames the bars in the combination size distribution plots from "N-body" to "N-type".

One important thing to note: currently the default value for `min_particles_in_combination` is 2, which means we don't catch any dijet / trijet (we did before because ljets were counted as a separate type). For example, a {2 jet, 1 ljet} combination was counted as **two particle types**, leading to dijets getting into the histograms. Maybe consider dropping the value to 1.