### PR TITLE
Add cuts in postprocessing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -155,6 +155,7 @@ post_processing_task_config:
   # ===PROCESSING===
   peak_detection_bin_width_gev: 10.0 
   z_peak_cutoff: 115.0   # GeV; drop dilepton masses below this to cut the Z peak (0 disables)
+  max_mass_cutoff: 10000.0   # GeV (10 TeV); drop masses above this in every channel (0 disables)
 
 # --- 4. Histogram Creation ---------------------------------------------------
 # Builds ROOT histograms from processed invariant-mass arrays.

--- a/config.yaml
+++ b/config.yaml
@@ -154,6 +154,7 @@ post_processing_task_config:
 
   # ===PROCESSING===
   peak_detection_bin_width_gev: 10.0 
+  z_peak_cutoff: 115.0   # GeV; drop dilepton masses below this to cut the Z peak (0 disables)
 
 # --- 4. Histogram Creation ---------------------------------------------------
 # Builds ROOT histograms from processed invariant-mass arrays.

--- a/domain/config.py
+++ b/domain/config.py
@@ -152,7 +152,9 @@ class PostProcessingConfig:
     
     # Processing parameters
     peak_detection_bin_width_gev: float = 10.0
-    
+
+    z_peak_cutoff: float = 115.0
+
     def __post_init__(self):
         """Validate post-processing configuration."""
         if not self.input_dir:
@@ -161,6 +163,8 @@ class PostProcessingConfig:
             raise ValueError("output_dir cannot be empty")
         if self.peak_detection_bin_width_gev <= 0:
             raise ValueError(f"peak_detection_bin_width_gev must be positive, got {self.peak_detection_bin_width_gev}")
+        if self.z_peak_cutoff < 0:
+            raise ValueError(f"z_peak_cutoff must be non-negative, got {self.z_peak_cutoff}")
 
 
 @dataclass(frozen=True)
@@ -340,6 +344,7 @@ class PipelineConfig:
                 input_dir=post_dict["input_dir"],
                 output_dir=post_dict["output_dir"],
                 peak_detection_bin_width_gev=post_dict.get("peak_detection_bin_width_gev", 10.0),
+                z_peak_cutoff=post_dict.get("z_peak_cutoff", 115.0),
             )
         
         # Parse histogram creation config if enabled

--- a/domain/config.py
+++ b/domain/config.py
@@ -154,6 +154,7 @@ class PostProcessingConfig:
     peak_detection_bin_width_gev: float = 10.0
 
     z_peak_cutoff: float = 115.0
+    max_mass_cutoff: float = 10_000.0
 
     def __post_init__(self):
         """Validate post-processing configuration."""
@@ -165,6 +166,8 @@ class PostProcessingConfig:
             raise ValueError(f"peak_detection_bin_width_gev must be positive, got {self.peak_detection_bin_width_gev}")
         if self.z_peak_cutoff < 0:
             raise ValueError(f"z_peak_cutoff must be non-negative, got {self.z_peak_cutoff}")
+        if self.max_mass_cutoff < 0:
+            raise ValueError(f"max_mass_cutoff must be non-negative, got {self.max_mass_cutoff}")
 
 
 @dataclass(frozen=True)
@@ -345,6 +348,7 @@ class PipelineConfig:
                 output_dir=post_dict["output_dir"],
                 peak_detection_bin_width_gev=post_dict.get("peak_detection_bin_width_gev", 10.0),
                 z_peak_cutoff=post_dict.get("z_peak_cutoff", 115.0),
+                max_mass_cutoff=post_dict.get("max_mass_cutoff", 10_000.0),
             )
         
         # Parse histogram creation config if enabled

--- a/orchestration/handlers/post_processing_handler.py
+++ b/orchestration/handlers/post_processing_handler.py
@@ -34,6 +34,7 @@ class PostProcessingHandler(StateHandler):
             "input_dir": pp.input_dir,
             "output_dir": pp.output_dir,
             "peak_detection_bin_width_gev": pp.peak_detection_bin_width_gev,
+            "z_peak_cutoff": pp.z_peak_cutoff,
             "batch_job_index": context.config.batch_job_index,
         }
 

--- a/orchestration/handlers/post_processing_handler.py
+++ b/orchestration/handlers/post_processing_handler.py
@@ -35,6 +35,7 @@ class PostProcessingHandler(StateHandler):
             "output_dir": pp.output_dir,
             "peak_detection_bin_width_gev": pp.peak_detection_bin_width_gev,
             "z_peak_cutoff": pp.z_peak_cutoff,
+            "max_mass_cutoff": pp.max_mass_cutoff,
             "batch_job_index": context.config.batch_job_index,
         }
 

--- a/services/pipelines/post_processing_pipeline.py
+++ b/services/pipelines/post_processing_pipeline.py
@@ -32,26 +32,23 @@ _DILEPTON_LETTERS = frozenset({'e', 'm'})
 
 def _dilepton_flavor(signature: str) -> bool:
     """
-    Return True when the IM part of ``signature`` is exactly two same-flavour
-    leptons (an ee or a mumu pair), else False.
+    Return True when the IM part of ``signature`` contains a same-flavor
+    lepton pair (an ee or a mumu pair), else False.
     """
     match = _IM_PART_PATTERN.search(signature)
     if not match:
         return False
 
     particles = _IM_PARTICLE_PATTERN.findall(match.group(1))
-    if len(particles) != 2:
-        return False
-
-    letters = {letter for letter, _rank in particles}
-    return len(letters) == 1 and letters.pop() in _DILEPTON_LETTERS
+    letters = [letter for letter, _rank in particles]
+    return any(letters.count(flavor) >= 2 for flavor in _DILEPTON_LETTERS)
 
 
 def _apply_z_peak_cut(
     arr: np.ndarray, signature: str, z_peak_cutoff: float, logger: logging.Logger
 ) -> np.ndarray:
     """
-    Drop masses below ``z_peak_cutoff`` GeV for same-flavour dilepton channels.
+    Drop masses below ``z_peak_cutoff`` GeV for channels containing same-flavour dileptons.
 
     The array is returned untouched for every other
     channel and when the cut is disabled (cutoff <= 0).

--- a/services/pipelines/post_processing_pipeline.py
+++ b/services/pipelines/post_processing_pipeline.py
@@ -22,12 +22,63 @@ from services.storage.sqlite_shards import (
 )
 
 
+DEFAULT_Z_PEAK_CUTOFF_GEV = 115.0
+
+# Signature layout: <prefix>_FS_<final_state>_IM_<letter><rank>...
+_IM_PART_PATTERN = re.compile(r'_IM_([a-z0-9]+)(?:_main|_outliers)?$')
+_IM_PARTICLE_PATTERN = re.compile(r'([emjgtb])(\d+)')
+_DILEPTON_LETTERS = frozenset({'e', 'm'})
+
+
+def _dilepton_flavor(signature: str) -> bool:
+    """
+    Return True when the IM part of ``signature`` is exactly two same-flavour
+    leptons (an ee or a mumu pair), else False.
+    """
+    match = _IM_PART_PATTERN.search(signature)
+    if not match:
+        return False
+
+    particles = _IM_PARTICLE_PATTERN.findall(match.group(1))
+    if len(particles) != 2:
+        return False
+
+    letters = {letter for letter, _rank in particles}
+    return len(letters) == 1 and letters.pop() in _DILEPTON_LETTERS
+
+
+def _apply_z_peak_cut(
+    arr: np.ndarray, signature: str, z_peak_cutoff: float, logger: logging.Logger
+) -> Tuple[np.ndarray, int]:
+    """
+    Drop masses below ``z_peak_cutoff`` GeV for same-flavour dilepton channels.
+
+    Returns (array, n_removed); the array is returned untouched for every other
+    channel and when the cut is disabled (cutoff <= 0).
+    """
+    if z_peak_cutoff <= 0:
+        return arr, 0
+
+    if not _dilepton_flavor(signature):
+        return arr, 0
+
+    kept = arr[arr >= z_peak_cutoff]
+    removed = len(arr) - len(kept)
+    if removed:
+        logger.debug(
+            f"{signature}: Z-peak cut removed {removed} dilepton values "
+            f"below {z_peak_cutoff:.1f} GeV"
+        )
+    return kept, removed
+
+
 def process_im_arrays(config: Dict, file_list: Optional[List[str]] = None) -> List[str]:
     logger = _init_logging()
 
     input_dir = config["input_dir"]
     output_dir = config["output_dir"]
     peak_detection_bin_width_gev = config["peak_detection_bin_width_gev"]
+    z_peak_cutoff = config["z_peak_cutoff"]
 
     os.makedirs(output_dir, exist_ok=True)
 
@@ -89,7 +140,7 @@ def process_im_arrays(config: Dict, file_list: Optional[List[str]] = None) -> Li
     for im_array_filename in im_array_files:
         try:
             output_files = _process_single_array(
-                im_array_filename, input_dir, output_dir, peak_detection_bin_width_gev, logger
+                im_array_filename, input_dir, output_dir, peak_detection_bin_width_gev, logger, z_peak_cutoff
             )
             if output_files:
                 processed_files.extend(output_files)
@@ -104,6 +155,7 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
     input_dir = config["input_dir"]
     output_dir = config["output_dir"]
     bin_width = config["peak_detection_bin_width_gev"]
+    z_peak_cutoff = config["z_peak_cutoff"]
 
     batch_idx = config.get("batch_job_index")
     if batch_idx is None:
@@ -167,6 +219,11 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
             if len(arr) == 0:
                 continue
 
+            # Remove the Z resonance before peak detection
+            arr, _removed = _apply_z_peak_cut(arr, fs_im_key, z_peak_cutoff, logger)
+            if len(arr) == 0:
+                continue
+
             peak_mass = _find_rightmost_highest_peak(arr, bin_width, logger)
             filtered = arr if peak_mass is None else arr[arr >= peak_mass]
             if len(filtered) == 0:
@@ -195,13 +252,22 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
 
 def _process_single_array(
     filename: str, input_dir: str, output_dir: str,
-    peak_detection_bin_width_gev: float, logger: logging.Logger
+    peak_detection_bin_width_gev: float, logger: logging.Logger,
+    z_peak_cutoff: float = DEFAULT_Z_PEAK_CUTOFF_GEV
 ) -> List[str]:
     file_path = os.path.join(input_dir, filename)
     im_array = np.load(file_path)
 
     if len(im_array) == 0:
         logger.warning(f"Array {filename} is empty, skipping")
+        return []
+
+    base_name = filename.replace(".npy", "")
+
+    # Remove the Z resonance before peak detection
+    im_array, _removed = _apply_z_peak_cut(im_array, base_name, z_peak_cutoff, logger)
+    if len(im_array) == 0:
+        logger.warning(f"Array {filename} is empty after the Z-peak cut, skipping")
         return []
 
     bin_width = peak_detection_bin_width_gev
@@ -223,7 +289,6 @@ def _process_single_array(
 
     main_array, outliers_array = _split_by_first_empty_bin(filtered_array, bin_width, logger)
 
-    base_name = filename.replace(".npy", "")
     output_files = []
 
     if len(main_array) > 0:

--- a/services/pipelines/post_processing_pipeline.py
+++ b/services/pipelines/post_processing_pipeline.py
@@ -23,6 +23,7 @@ from services.storage.sqlite_shards import (
 
 
 DEFAULT_Z_PEAK_CUTOFF_GEV = 115.0
+DEFAULT_MAX_MASS_CUTOFF_GEV = 10_000.0
 
 # Signature layout: <prefix>_FS_<final_state>_IM_<letter><rank>...
 _IM_PART_PATTERN = re.compile(r'_IM_([a-z0-9]+)(?:_main|_outliers)?$')
@@ -79,6 +80,7 @@ def process_im_arrays(config: Dict, file_list: Optional[List[str]] = None) -> Li
     output_dir = config["output_dir"]
     peak_detection_bin_width_gev = config["peak_detection_bin_width_gev"]
     z_peak_cutoff = config["z_peak_cutoff"]
+    max_mass_cutoff = config["max_mass_cutoff"]
 
     os.makedirs(output_dir, exist_ok=True)
 
@@ -140,7 +142,8 @@ def process_im_arrays(config: Dict, file_list: Optional[List[str]] = None) -> Li
     for im_array_filename in im_array_files:
         try:
             output_files = _process_single_array(
-                im_array_filename, input_dir, output_dir, peak_detection_bin_width_gev, logger, z_peak_cutoff
+                im_array_filename, input_dir, output_dir, peak_detection_bin_width_gev, logger,
+                z_peak_cutoff, max_mass_cutoff
             )
             if output_files:
                 processed_files.extend(output_files)
@@ -156,6 +159,7 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
     output_dir = config["output_dir"]
     bin_width = config["peak_detection_bin_width_gev"]
     z_peak_cutoff = config["z_peak_cutoff"]
+    max_mass_cutoff = config["max_mass_cutoff"]
 
     batch_idx = config.get("batch_job_index")
     if batch_idx is None:
@@ -221,6 +225,7 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
 
             # Remove the Z resonance before peak detection
             arr, _removed = _apply_z_peak_cut(arr, fs_im_key, z_peak_cutoff, logger)
+            arr = arr[arr <= max_mass_cutoff] if max_mass_cutoff > 0 else arr
             if len(arr) == 0:
                 continue
 
@@ -253,7 +258,8 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
 def _process_single_array(
     filename: str, input_dir: str, output_dir: str,
     peak_detection_bin_width_gev: float, logger: logging.Logger,
-    z_peak_cutoff: float = DEFAULT_Z_PEAK_CUTOFF_GEV
+    z_peak_cutoff: float = DEFAULT_Z_PEAK_CUTOFF_GEV,
+    max_mass_cutoff: float = DEFAULT_MAX_MASS_CUTOFF_GEV
 ) -> List[str]:
     file_path = os.path.join(input_dir, filename)
     im_array = np.load(file_path)
@@ -266,6 +272,7 @@ def _process_single_array(
 
     # Remove the Z resonance before peak detection
     im_array, _removed = _apply_z_peak_cut(im_array, base_name, z_peak_cutoff, logger)
+    im_array = im_array[im_array <= max_mass_cutoff] if max_mass_cutoff > 0 else im_array
     if len(im_array) == 0:
         logger.warning(f"Array {filename} is empty after the Z-peak cut, skipping")
         return []

--- a/services/pipelines/post_processing_pipeline.py
+++ b/services/pipelines/post_processing_pipeline.py
@@ -2,10 +2,11 @@
 Post-processing pipeline for invariant mass arrays.
 
 Processes IM arrays to:
-1. Bin data using specified bin widths
-2. Find the rightmost highest bin (peak)
-3. Remove data before the peak
-4. Split arrays by the first empty bin into main + outliers
+1. Remove the Z-peak for appropriate channels + apply 10TeV hard cutoff
+2. Bin data using specified bin widths
+3. Find the rightmost highest bin (peak)
+4. Remove data before the peak
+5. Split arrays by the first empty bin into main + outliers
 """
 import logging
 import sys
@@ -22,8 +23,6 @@ from services.storage.sqlite_shards import (
 )
 
 
-DEFAULT_Z_PEAK_CUTOFF_GEV = 115.0
-DEFAULT_MAX_MASS_CUTOFF_GEV = 10_000.0
 
 # Signature layout: <prefix>_FS_<final_state>_IM_<letter><rank>...
 _IM_PART_PATTERN = re.compile(r'_IM_([a-z0-9]+)(?:_main|_outliers)?$')
@@ -50,18 +49,18 @@ def _dilepton_flavor(signature: str) -> bool:
 
 def _apply_z_peak_cut(
     arr: np.ndarray, signature: str, z_peak_cutoff: float, logger: logging.Logger
-) -> Tuple[np.ndarray, int]:
+) -> np.ndarray:
     """
     Drop masses below ``z_peak_cutoff`` GeV for same-flavour dilepton channels.
 
-    Returns (array, n_removed); the array is returned untouched for every other
+    The array is returned untouched for every other
     channel and when the cut is disabled (cutoff <= 0).
     """
     if z_peak_cutoff <= 0:
-        return arr, 0
+        return arr
 
     if not _dilepton_flavor(signature):
-        return arr, 0
+        return arr
 
     kept = arr[arr >= z_peak_cutoff]
     removed = len(arr) - len(kept)
@@ -70,7 +69,7 @@ def _apply_z_peak_cut(
             f"{signature}: Z-peak cut removed {removed} dilepton values "
             f"below {z_peak_cutoff:.1f} GeV"
         )
-    return kept, removed
+    return kept
 
 
 def process_im_arrays(config: Dict, file_list: Optional[List[str]] = None) -> List[str]:
@@ -224,7 +223,7 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
                 continue
 
             # Remove the Z resonance before peak detection
-            arr, _removed = _apply_z_peak_cut(arr, fs_im_key, z_peak_cutoff, logger)
+            arr = _apply_z_peak_cut(arr, fs_im_key, z_peak_cutoff, logger)
             arr = arr[arr <= max_mass_cutoff] if max_mass_cutoff > 0 else arr
             if len(arr) == 0:
                 continue
@@ -245,7 +244,7 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
             processed += 1                          # ← new
             if processed % COMMIT_EVERY == 0:       # ← new
                 writer.commit()                     # ← new: periodic commit
-                logger.info(f"Post-processing progress: {processed}/{len(fs_im_key)} signatures committed")  # ← new
+                logger.info(f"Post-processing progress: {processed}/{len(fs_im_groups)} signatures committed")  # ← new
 
         writer.commit()  # ← final commit for remainder    
     finally:
@@ -258,8 +257,8 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
 def _process_single_array(
     filename: str, input_dir: str, output_dir: str,
     peak_detection_bin_width_gev: float, logger: logging.Logger,
-    z_peak_cutoff: float = DEFAULT_Z_PEAK_CUTOFF_GEV,
-    max_mass_cutoff: float = DEFAULT_MAX_MASS_CUTOFF_GEV
+    z_peak_cutoff: float,
+    max_mass_cutoff: float
 ) -> List[str]:
     file_path = os.path.join(input_dir, filename)
     im_array = np.load(file_path)
@@ -271,7 +270,7 @@ def _process_single_array(
     base_name = filename.replace(".npy", "")
 
     # Remove the Z resonance before peak detection
-    im_array, _removed = _apply_z_peak_cut(im_array, base_name, z_peak_cutoff, logger)
+    im_array = _apply_z_peak_cut(im_array, base_name, z_peak_cutoff, logger)
     im_array = im_array[im_array <= max_mass_cutoff] if max_mass_cutoff > 0 else im_array
     if len(im_array) == 0:
         logger.warning(f"Array {filename} is empty after the Z-peak cut, skipping")

--- a/services/pipelines/post_processing_pipeline.py
+++ b/services/pipelines/post_processing_pipeline.py
@@ -241,7 +241,7 @@ def _process_im_sqlite(config: Dict, sqlite_files: List[str], logger: logging.Lo
             processed += 1                          # ← new
             if processed % COMMIT_EVERY == 0:       # ← new
                 writer.commit()                     # ← new: periodic commit
-                logger.info(f"Post-processing progress: {processed}/{len(keys_to_process)} signatures committed")  # ← new
+                logger.info(f"Post-processing progress: {processed}/{len(fs_im_groups)} signatures committed")  # ← new
 
         writer.commit()  # ← final commit for remainder    
     finally:


### PR DESCRIPTION
Adds:
* A cut at 10TeV for all channels, configurable via `max_mass_cutoff`
* A cut below 115GeV for dilepton same-flavor channels, to cut Z peaks

It's worth noting that the Z peak cut happens *before* finding the rightmost highest peak.

Not sure if this is what we want, from an analysis perspective. 